### PR TITLE
return error codes on failed password validation instead of human-readable text messages

### DIFF
--- a/app/Language/en/Validation.php
+++ b/app/Language/en/Validation.php
@@ -1,4 +1,0 @@
-<?php
-
-// override core en language system validation or define your own en language validation message
-return [];

--- a/app/Language/en/Validation.php
+++ b/app/Language/en/Validation.php
@@ -1,12 +1,4 @@
 <?php
 
 // override core en language system validation or define your own en language validation message
-return [
-    'missingField' => 'The {field} field is required.',
-    'missingLowercaseLetter' => 'The {field} field must be at least one lowercase letter.',
-    'missingUppercaseLetter' => 'The {field} field must be at least one uppercase letter.',
-    'missingNumber' => 'The {field} field must have at least one number.',
-    'missingSpecialCharacter' => 'The {field} field must have at least one special character.',
-    'tooShort' => 'The {field} field must be at least {min_length} characters in length.',
-    'password' => 'password',
-];
+return [];

--- a/app/Validation/PasswordRules.php
+++ b/app/Validation/PasswordRules.php
@@ -9,18 +9,12 @@ class PasswordRules
     public function valid_password(string $password, ?string &$error = null): bool
     {
         if ($password === '') {
-            $error = lang('Validation.missingField', ['field' => lang('Validation.password')]);
+            $error = PasswordRulesError::PasswordMissingField->value;
             return false;
         }
 
         if (mb_strlen($password) < self::PASSWORD_MIN_LENGTH) {
-            $error = lang(
-                'Validation.tooShort',
-                [
-                    'field' => lang('Validation.password'),
-                    'min_length' => self::PASSWORD_MIN_LENGTH
-                ]
-            );
+            $error = PasswordRulesError::PasswordTooShort->value;
             return false;
         }
 
@@ -30,22 +24,22 @@ class PasswordRules
         $regex_special = '/[!@#$%^&*()\-_=+{};:,<.>§~ ]/';
 
         if (preg_match_all($regex_lowercase, $password) < 1) {
-            $error = lang('Validation.missingLowercaseLetter', ['field' => lang('Validation.password')]);
+            $error = PasswordRulesError::PasswordMissingLowercaseLetter->value;
             return false;
         }
 
         if (preg_match_all($regex_uppercase, $password) < 1) {
-            $error = lang('Validation.missingUppercaseLetter', ['field' => lang('Validation.password')]);
+            $error = PasswordRulesError::PasswordMissingUppercaseLetter->value;
             return false;
         }
 
         if (preg_match_all($regex_number, $password) < 1) {
-            $error = lang('Validation.missingNumber', ['field' => lang('Validation.password')]);
+            $error = PasswordRulesError::PasswordMissingNumber->value;
             return false;
         }
 
         if (preg_match_all($regex_special, $password) < 1) {
-            $error = lang('Validation.missingSpecialCharacter', ['field' => lang('Validation.password')]);
+            $error = PasswordRulesError::PasswordMissingSpecialCharacter->value;
             return false;
         }
 

--- a/app/Validation/PasswordRulesError.php
+++ b/app/Validation/PasswordRulesError.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Validation;
+
+enum PasswordRulesError: string
+{
+    case PasswordMissingField = 'PASSWORD_MISSING_FIELD';
+    case PasswordTooShort = 'PASSWORD_TOO_SHORT';
+    case PasswordMissingLowercaseLetter = 'PASSWORD_MISSING_LOWERCASE_LETTER';
+    case PasswordMissingUppercaseLetter = 'PASSWORD_MISSING_UPPERCASE_LETTER';
+    case PasswordMissingNumber = 'PASSWORD_MISSING_NUMBER';
+    case PasswordMissingSpecialCharacter = 'PASSWORD_MISSING_SPECIAL_CHARACTER';
+}


### PR DESCRIPTION
As soon as the frontend also does a full validation, these error codes will only be helpful as a fallback and should never be necessary to be read in the frontend.