### PR TITLE
feat: add table for team members and return their data as part of the Event data structure

### DIFF
--- a/app/Controllers/Event.php
+++ b/app/Controllers/Event.php
@@ -5,8 +5,8 @@ namespace App\Controllers;
 use App\Controllers\BaseController;
 use App\Models\EventModel;
 use App\Models\SocialMediaLinkModel;
-use App\Models\SocialMediaTypeModel;
 use App\Models\SpeakerModel;
+use App\Models\TeamMemberModel;
 
 class Event extends BaseController
 {
@@ -23,13 +23,22 @@ class Event extends BaseController
 
         $speakerModel = new SpeakerModel();
         $speakers = $speakerModel->getPublished($event['id']);
-        $userIds = array_column($speakers, 'user_id');
+        $speakerUserIds = array_column($speakers, 'user_id');
+
+        $teamMemberModel = new TeamMemberModel();
+        $teamMembers = $teamMemberModel->getPublished($event['id']);
+        $teamMemberUserIds = array_column($teamMembers, 'user_id');
 
         $socialMediaLinkModel = new SocialMediaLinkModel();
-        $socialMediaLinks = $socialMediaLinkModel->get_by_user_ids($userIds);
+        $speakersSocialMediaLinks = $socialMediaLinkModel->get_by_user_ids($speakerUserIds);
+        $teamMembersSocialMediaLinks = $socialMediaLinkModel->get_by_user_ids($teamMemberUserIds);
 
         foreach ($speakers as &$speaker) {
-            $speaker['social_media_links'] = $socialMediaLinks[$speaker['user_id']] ?? [];
+            $speaker['social_media_links'] = $speakersSocialMediaLinks[$speaker['user_id']] ?? [];
+        }
+
+        foreach ($teamMembers as &$teamMember) {
+            $teamMember['social_media_links'] = $teamMembersSocialMediaLinks[$teamMember['user_id']] ?? [];
         }
 
         $event['year'] = $year;
@@ -37,6 +46,7 @@ class Event extends BaseController
         return $this->response->setJSON([
             'event' => $event,
             'speakers' => $speakers,
+            'team_members' => $teamMembers,
         ]);
     }
 }

--- a/app/Database/Migrations/2024-10-07-172154_AddTeamMember.php
+++ b/app/Database/Migrations/2024-10-07-172154_AddTeamMember.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class AddTeamMember extends Migration
+{
+    public function up()
+    {
+        // The Speaker table and the TeamMember table are exactly identical, except
+        // for their name. Therefore, we can reuse the Speaker table fields for the
+        // TeamMember table.
+        $speakerTableFields = $this->db->getFieldData('Speaker');
+
+        $fields = [];
+        foreach ($speakerTableFields as $field) {
+            $fields[$field->name] = [
+                'type' => $field->type,
+                'constraint' => $field->max_length ?? null,
+                'unsigned' => $field->unsigned ?? false,
+                'null' => $field->null ?? false,
+                'default' => $field->default ?? null,
+                'auto_increment' => $field->name === 'id',
+            ];
+        }
+
+        $this->forge->addField($fields);
+        $this->forge->addKey('id', true);
+        $this->forge->createTable('TeamMember');
+    }
+
+    public function down()
+    {
+        $this->forge->dropTable('TeamMember');
+    }
+}

--- a/app/Database/Seeds/MainSeeder.php
+++ b/app/Database/Seeds/MainSeeder.php
@@ -14,5 +14,6 @@ class MainSeeder extends Seeder
         $this->call('SpeakerSeeder');
         $this->call('SocialMediaTypeSeeder');
         $this->call('SocialMediaLinkSeeder');
+        $this->call('TeamMemberSeeder');
     }
 }

--- a/app/Database/Seeds/TeamMemberSeeder.php
+++ b/app/Database/Seeds/TeamMemberSeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Database\Seeds;
+
+use CodeIgniter\Database\Seeder;
+
+class TeamMemberSeeder extends Seeder
+{
+    public function run()
+    {
+        $this->db->table('TeamMember')->insert([
+            'name' => 'coder2k',
+            'user_id' => 1,
+            'event_id' => 1,
+            'short_bio' => 'Test-Conf Host',
+            'bio' => 'Das ist die Beschreibung von coder2k, wenn er als Team-Member angezeigt wird. Die ist anders als die Beschreibung, die angezeigt wird, wenn er als Speaker angezeigt wird.',
+            'photo' => 'images/coder2k.jpg',
+            'photo_mime_type' => 'image/jpeg',
+            'is_approved' => true,
+            'visible_from' => date('2024-06-01 15:00:00'),
+            'updated_at' => date('2024-06-01 15:01:00'),
+        ]);
+        $this->db->table('TeamMember')->insert([
+            'name' => 'codingPurpurTentakel',
+            'user_id' => 4,
+            'event_id' => 1,
+            'short_bio' => 'Test-Conf Host',
+            'bio' => 'Das ist die Beschreibung von codingPurpurTentakel, wenn er als Team-Member angezeigt wird. Die ist anders als die Beschreibung, die angezeigt wird, wenn er als Speaker angezeigt wird.',
+            'photo' => 'images/codingPurpurTentakel.jpg',
+            'photo_mime_type' => 'image/jpeg',
+            'is_approved' => true,
+            'visible_from' => date('2024-06-01 15:00:00'),
+        ]);
+    }
+}

--- a/app/Models/GenericRoleModel.php
+++ b/app/Models/GenericRoleModel.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+/**
+ * Superclass for SpeakerModel and TeamMemberModel.
+ */
+class GenericRoleModel extends Model
+{
+    // child classes will have to set the protected $table field to make this class work
+
+    protected $allowedFields = ['name', 'user_id', 'event_id', 'short_bio', 'bio', 'photo', 'photo_mime_type', 'is_approved', 'visible_from'];
+    protected $useTimestamps = true;
+
+    public function get(int $id): array|null
+    {
+        return $this->select('id, name, short_bio, bio, photo, photo_mime_type, is_approved, visible_from')->where('id', $id)->first();
+    }
+
+    public function getPublished(int $eventId): array
+    {
+        $subQuery = $this->db->table($this->table)
+            ->select('id')
+            ->where("$this->table.user_id = outer_table.user_id")
+            ->where('is_approved', true)
+            ->where('visible_from <=', date('Y-m-d H:i:s'))
+            ->orderBy('updated_at', 'DESC')
+            ->limit(1)
+            ->getCompiledSelect();
+
+        $query = $this->db->table("$this->table AS outer_table")
+            ->select('user_id, name, short_bio, bio, photo')
+            ->where('event_id = ', $eventId)
+            ->where("id = ($subQuery)", null, false)
+            ->get()
+            ->getResultArray();
+
+        return $query;
+    }
+
+    public function create(
+        string $name,
+        int    $userId,
+        int    $eventId,
+        string $shortBio,
+        string $bio,
+        string $photo,
+        string $photoMimeType,
+        bool   $isActive,
+        string $visibleFrom,
+    ): int
+    {
+        return $this->insert([
+            'name' => $name,
+            'user_id' => $userId,
+            'event_id' => $eventId,
+            'short_bio' => $shortBio,
+            'bio' => $bio,
+            'photo' => $photo,
+            'photo_mime_type' => $photoMimeType,
+            'is_approved' => $isActive,
+            'visible_from' => $visibleFrom,
+        ]);
+    }
+}

--- a/app/Models/SpeakerModel.php
+++ b/app/Models/SpeakerModel.php
@@ -2,62 +2,7 @@
 
 namespace App\Models;
 
-use CodeIgniter\Model;
-
-class SpeakerModel extends Model
+class SpeakerModel extends GenericRoleModel
 {
     protected $table = 'Speaker';
-    protected $allowedFields = ['name', 'user_id', 'event_id', 'short_bio', 'bio', 'photo', 'photo_mime_type', 'is_approved', 'visible_from'];
-    protected $useTimestamps = true;
-
-    public function get(int $id): array|null
-    {
-        return $this->select('id, name, short_bio, bio, photo, photo_mime_type, is_approved, visible_from')->where('id', $id)->first();
-    }
-
-    public function getPublished(int $eventId): array
-    {
-        $subQuery = $this->db->table('Speaker')
-            ->select('id')
-            ->where('Speaker.user_id = outer_speaker.user_id')
-            ->where('is_approved', true)
-            ->where('visible_from <=', date('Y-m-d H:i:s'))
-            ->orderBy('updated_at', 'DESC')
-            ->limit(1)
-            ->getCompiledSelect();
-
-        $query = $this->db->table('Speaker AS outer_speaker')
-            ->select('user_id, name, short_bio, bio, photo')
-            ->where('event_id = ', $eventId)
-            ->where("id = ($subQuery)", null, false)
-            ->get()
-            ->getResultArray();
-
-        return $query;
-    }
-
-    public function create(
-        string $name,
-        int    $userId,
-        int    $eventId,
-        string $shortBio,
-        string $bio,
-        string $photo,
-        string $photoMimeType,
-        bool   $isActive,
-        string $visibleFrom,
-    ): int
-    {
-        return $this->insert([
-            'name' => $name,
-            'user_id' => $userId,
-            'event_id' => $eventId,
-            'short_bio' => $shortBio,
-            'bio' => $bio,
-            'photo' => $photo,
-            'photo_mime_type' => $photoMimeType,
-            'is_approved' => $isActive,
-            'visible_from' => $visibleFrom,
-        ]);
-    }
 }

--- a/app/Models/TeamMemberModel.php
+++ b/app/Models/TeamMemberModel.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Models;
+
+class TeamMemberModel extends GenericRoleModel
+{
+    protected $table = 'TeamMember';
+}


### PR DESCRIPTION
This will extend the JSON structure that's returned by the events endpoint. It will now look like this:

```json
{
  "event": {
    // ...
  },
  "speakers": [
    // ...
  ],
  "team_members": [
    // ...
  ]
}
```

The `team_members` field is structured in the exact same way as the `speakers` field.