### PR TITLE
feat: publish date for events

### DIFF
--- a/app/Controllers/Event.php
+++ b/app/Controllers/Event.php
@@ -15,17 +15,16 @@ use App\Models\TeamMemberModel;
 class Event extends BaseController
 {
     public function get(int|null $year = null) {
-        if ($year === null) {
-            $globalsModel = new GlobalsModel();
-            $globals = $globalsModel->read();
-            $year = $globals['default_year'];
-        }
         $eventModel = new EventModel();
-        $event = $eventModel->getByYear($year);
-        $eventId = $event['id'];
+        if ($year === null) {
+            $event = $eventModel->getLatestPublished();
+        } else {
+            $event = $eventModel->getByYear($year);
+        }
         if ($event === null) {
             return $this->response->setStatusCode(404);
         }
+        $eventId = $event['id'];
 
         $sponsorModel = new SponsorModel();
         $sponsors = $sponsorModel->getPublished($eventId);

--- a/app/Database/Migrations/2024-11-02-173722_AddEventPublishDate.php
+++ b/app/Database/Migrations/2024-11-02-173722_AddEventPublishDate.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class AddEventPublishDate extends Migration
+{
+    public function up()
+    {
+        $this->forge->addColumn('event', [
+            'publish_date' => [
+                'type' => 'DATETIME',
+                'null' => true,
+                'after' => 'description',
+            ],
+        ]);
+    }
+
+    public function down()
+    {
+        $this->forge->dropColumn('event', 'publish_date');
+    }
+}

--- a/app/Database/Seeds/EventSeeder.php
+++ b/app/Database/Seeds/EventSeeder.php
@@ -17,6 +17,7 @@ class EventSeeder extends Seeder
                 'discord_url' => 'https://discord.com/invite/tp4EnphfKb',
                 'twitch_url' => 'https://www.twitch.tv/coder2k',
                 'presskit_url' => 'https://test-conf.de/Test-Conf-Presskit.zip',
+                'publish_date' => date('2024-01-01 12:00:00'),
                 'schedule_visible_from' => date('2024-06-22 12:00:00'),
                 'trailer_youtube_id' => 'IW1vQAB6B18',
                 'description_headline' => 'Sei dabei!',

--- a/app/Database/Seeds/GlobalsSeeder.php
+++ b/app/Database/Seeds/GlobalsSeeder.php
@@ -9,12 +9,6 @@ class GlobalsSeeder extends Seeder
     public function run()
     {
         $this->db->table('Globals')->insert([
-            'key' => 'default_year',
-            'value' => '2024',
-            'created_at' => date('Y-m-d H:i:s'),
-            'updated_at' => date('Y-m-d H:i:s'),
-        ]);
-        $this->db->table('Globals')->insert([
             'key' => 'footer_text',
             'value' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam ac ante mollis, fermentum nunc nec, tincidunt nunc. Sed nec nunc nec nunc.',
             'created_at' => date('Y-m-d H:i:s'),

--- a/app/Models/EventModel.php
+++ b/app/Models/EventModel.php
@@ -19,6 +19,7 @@ class EventModel extends Model
         'trailer_youtube_id',
         'description_headline',
         'description',
+        'publish_date',
     ];
     protected $useTimestamps = true;
     protected array $casts = [
@@ -30,6 +31,7 @@ class EventModel extends Model
         return $this
             ->select('id, title, subtitle, start_date, end_date, discord_url, twitch_url, presskit_url, trailer_youtube_id, description_headline, description')
             ->where('id', $eventId)
+            ->where('publish_date <=', date('Y-m-d H:i:s'))
             ->first();
     }
 
@@ -38,6 +40,7 @@ class EventModel extends Model
         return $this
             ->select('id, title, subtitle, start_date, end_date, discord_url, twitch_url, presskit_url, trailer_youtube_id, description_headline, description')
             ->where('YEAR(start_date)', $year)
+            ->where('publish_date <=', date('Y-m-d H:i:s'))
             ->first();
     }
 
@@ -45,8 +48,18 @@ class EventModel extends Model
     {
         return $this
             ->select('id, title, subtitle, start_date, end_date, discord_url, twitch_url, presskit_url, trailer_youtube_id, description_headline, description')
+            ->where('publish_date <=', date('Y-m-d H:i:s'))
             ->orderBy('start_date', 'DESC')
             ->findAll();
+    }
+
+    public function getLatestPublished(): array|null
+    {
+        return $this
+            ->select('id, title, subtitle, start_date, end_date, discord_url, twitch_url, presskit_url, trailer_youtube_id, description_headline, description')
+            ->where('publish_date <=', date('Y-m-d H:i:s'))
+            ->orderBy('start_date', 'DESC')
+            ->first();
     }
 
     public function create(
@@ -60,6 +73,7 @@ class EventModel extends Model
         string $trailerYoutubeId,
         string $descriptionHeadline,
         string $description,
+        string|null $publishDate = null,
     ): int
     {
         return $this->insert([
@@ -73,6 +87,7 @@ class EventModel extends Model
             'trailer_youtube_id' => $trailerYoutubeId,
             'description_headline' => $descriptionHeadline,
             'description' => $description,
+            'publish_date' => $publishDate,
         ]);
     }
 }

--- a/app/Models/GlobalsModel.php
+++ b/app/Models/GlobalsModel.php
@@ -10,9 +10,7 @@ class GlobalsModel extends Model
     protected $allowedFields = ['key', 'value'];
     protected $useTimestamps = true;
 
-    private const REQUIRED_INT_KEYS = [
-        "default_year",
-    ];
+    private const REQUIRED_INT_KEYS = [];
     private const REQUIRED_STRING_KEYS = [
         "footer_text",
     ];
@@ -44,12 +42,8 @@ class GlobalsModel extends Model
         return $result;
     }
 
-    public function write(
-        int    $default_year,
-        string $footer_text,
-    )
+    public function write(string $footer_text)
     {
-        $this->where('key', 'default_year')->set(['value' => $default_year])->update();
         $this->where('key', 'footer_text')->set(['value' => $footer_text])->update();
     }
 }


### PR DESCRIPTION
- events now have a `publish_date` and are only visible if that date has already passed
- `default_year` has been removed from the globals
- the `api/events` route now defaults to the newest event that has already been published (which is 2024 using the data that's inside the seeders)