### PR TITLE
"forgot password" mechanic

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -23,6 +23,8 @@ $routes->get('account/username/exists', [Account::class, 'usernameExists']);
 $routes->get('account/email/exists', [Account::class, 'emailExists']);
 $routes->get('account/roles', [Account::class, 'roles'], ['filter' => AuthFilter::class]);
 $routes->post('account/register', [Account::class, 'register']);
+$routes->post('account/forgot-password', [Account::class, 'forgotPassword']);
+$routes->post('account/reset-password', [Account::class, 'resetPassword']);
 $routes->post('account/login', [Account::class, 'login']);
 $routes->post('account/logout', [Account::class, 'logout']);
 $routes->post('account/verify', [Account::class, 'verify']);

--- a/app/Controllers/Account.php
+++ b/app/Controllers/Account.php
@@ -4,11 +4,13 @@ namespace App\Controllers;
 
 use App\Helpers\EmailHelper;
 use App\Models\AccountModel;
+use App\Models\PasswordResetTokenModel;
 use App\Models\RolesModel;
 use App\Models\UserModel;
 use CodeIgniter\HTTP\ResponseInterface;
 use Config\Services;
 use App\Models\VerificationTokenModel;
+use Random\RandomException;
 
 class Account extends BaseController
 {
@@ -20,6 +22,15 @@ class Account extends BaseController
 
     const VERIFICATION_RULES = [
         'token' => 'required|trim',
+    ];
+
+    const FORGOT_PASSWORD_RULES = [
+        'username_or_email' => 'required|max_length[320]',
+    ];
+
+    const RESET_PASSWORD_RULES = [
+        'token' => 'required|trim',
+        'new_password' => 'required|valid_password',
     ];
 
     public function register()
@@ -85,6 +96,120 @@ class Account extends BaseController
         return $this->response->setJSON(['message' => 'success'])->setStatusCode(201);
     }
 
+    /**
+     * Sends an email to the user with a link to reset the password.
+     * @return ResponseInterface The response.
+     */
+    public function forgotPassword(): ResponseInterface
+    {
+        $data = $this->request->getJSON(assoc: true);
+
+        if (!$this->validateData($data, self::FORGOT_PASSWORD_RULES)) {
+            return $this->response->setJSON($this->validator->getErrors())->setStatusCode(400);
+        }
+
+        $validData = $this->validator->getValidated();
+        $username_or_email = $validData['username_or_email'];
+
+        $accountModel = model(AccountModel::class);
+        $account = $accountModel->getAccountByUsernameOrEmail($username_or_email);
+        if ($account === null) {
+            // We could "pretend" that the email was sent successfully, but it wouldn't be reasonable,
+            // because it's possible to find out if an email address is registered or not, anyway. So
+            // this wouldn't give us any security advantage, but it would make the user experience worse.
+            return $this->response->setJSON(['error' => 'UNKNOWN_USERNAME_OR_EMAIL'])->setStatusCode(404);
+        }
+
+        // Create a password reset token. It is possible that there are multiple reset tokens for the
+        // same user. They all remain valid until they expire. But when a user uses any of those tokens
+        // to reset their password, all other tokens are deleted (see the resetPassword method).
+        $passwordResetTokenModel = model(PasswordResetTokenModel::class);
+        try {
+            $token = bin2hex(random_bytes(64));
+        } catch (RandomException) {
+            return $this->response->setStatusCode(500);
+        }
+        $expiresAt = date('Y-m-d H:i:s', strtotime('+1 day'));
+        $passwordResetTokenModel->store($token, $account['user_id'], $expiresAt);
+
+        // Base URL is something that ends with /api/, so we need to remove api/ from the base URL.
+        $baseUrl = base_url();
+        $suffix = "api/";
+        if (str_ends_with($baseUrl, $suffix)) {
+            $baseUrl = substr($baseUrl, 0, -strlen($suffix));
+        }
+
+        $resetPasswordLink = $baseUrl . 'reset-password' . '?token=' . $token;
+
+        // We could avoid including the username in the email, because at first glance
+        // a hacker who has control over the email account, could find out the username.
+        // But after the hacker has reset the password, they could find out the username
+        // anyway, because they could log in.
+        EmailHelper::send(
+            $account['email'],
+            'Passwort zurücksetzen',
+            view(
+                'email/account/forgot_password',
+                [
+                    'username' => $account['username'],
+                    'resetPasswordLink' => $resetPasswordLink,
+                ]
+            )
+        );
+        return $this->response->setJSON(['message' => 'success']);
+    }
+
+    /**
+     * Resets the password of a user that has requested a password reset.
+     * @return ResponseInterface The response.
+     */
+    public function resetPassword(): ResponseInterface
+    {
+        $data = $this->request->getJSON(assoc: true);
+
+        if (!$this->validateData($data, self::RESET_PASSWORD_RULES)) {
+            return $this->response->setJSON($this->validator->getErrors())->setStatusCode(400);
+        }
+
+        $validData = $this->validator->getValidated();
+        $token = $validData['token'];
+        $newPassword = $validData['new_password'];
+
+        $passwordResetTokenModel = model(PasswordResetTokenModel::class);
+        // Delete all expired tokens so that we don't have to check if the token is expired.
+        $passwordResetTokenModel->deleteExpiredTokens();
+
+        $entry = $passwordResetTokenModel->get($token);
+        if ($entry === null) {
+            return $this->response->setJSON(['error' => 'TOKEN_EXPIRED_OR_DOES_NOT_EXIST'])->setStatusCode(404);
+        }
+
+        $accountModel = model(AccountModel::class);
+        $account = $accountModel->get($entry['user_id']);
+        if ($account === null) {
+            // This should never happen, because the token is only created when the account exists.
+            return $this->response->setStatusCode(500);
+        }
+
+        $accountModel->changePasswordHash($entry['user_id'], password_hash($newPassword, PASSWORD_DEFAULT));
+
+        // Delete the used token as well as all other tokens of the same user that may exist.
+        $passwordResetTokenModel->deleteTokensOfUser($entry['user_id']);
+
+        EmailHelper::send(
+            $account['email'],
+            'Dein Passwort wurde geändert',
+            view(
+                'email/account/password_reset',
+                [
+                    'username' => $account['username'],
+                ]
+            )
+        );
+
+        return $this->response->setJSON(['message' => 'success']);
+    }
+
     public function usernameExists()
     {
         $model = model(AccountModel::class);
@@ -122,6 +247,11 @@ class Account extends BaseController
 
     public function login()
     {
+        // On each login, we delete all expired password reset tokens. There's no deeper reason  to
+        // do it exactly here, but we have to do it somewhere. ¯\_(ツ)_/¯
+        $passwordResetTokenModel = model(PasswordResetTokenModel::class);
+        $passwordResetTokenModel->deleteExpiredTokens();
+
         $usernameOrEmail = trim($this->request->getJsonVar('username_or_email'));
         $password = $this->request->getJsonVar('password');
 

--- a/app/Controllers/Account.php
+++ b/app/Controllers/Account.php
@@ -12,6 +12,12 @@ use App\Models\VerificationTokenModel;
 
 class Account extends BaseController
 {
+    const REGISTER_RULES = [
+        'username' => 'required|trim|alpha_dash|min_length[3]|max_length[30]',
+        'password' => 'required|valid_password',
+        'email' => 'required|trim|valid_email|max_length[320]',
+    ];
+
     const VERIFICATION_RULES = [
         'token' => 'required|trim',
     ];
@@ -25,13 +31,7 @@ class Account extends BaseController
 
         $data = $this->request->getJSON(assoc: true);
 
-        $rules = [
-            'username' => 'required|trim|alpha_dash|min_length[3]|max_length[30]',
-            'password' => 'required|valid_password',
-            'email' => 'required|trim|valid_email|max_length[320]',
-        ];
-
-        if (!$this->validateData($data, $rules)) {
+        if (!$this->validateData($data, self::REGISTER_RULES)) {
             return $this->response->setJSON($this->validator->getErrors())->setStatusCode(400);
         }
 

--- a/app/Database/Migrations/2025-01-06-153009_AddPasswordResetToken.php
+++ b/app/Database/Migrations/2025-01-06-153009_AddPasswordResetToken.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class AddPasswordResetToken extends Migration
+{
+    public function up()
+    {
+        $this->forge->addField([
+            'token' => [
+                'type' => 'VARCHAR',
+                'constraint' => 255,
+            ],
+            'user_id' => [
+                'type' => 'INT',
+                'unsigned' => true,
+            ],
+            'expires_at' => [
+                'type' => 'DATETIME',
+            ],
+            'created_at' => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+            'updated_at' => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+            'deleted_at' => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+        ]);
+        $this->forge->addPrimaryKey('token');
+        $this->forge->addForeignKey('user_id', 'User', 'id');
+        $this->forge->createTable('PasswordResetToken');
+    }
+
+    public function down()
+    {
+        $this->forge->dropTable('PasswordResetToken');
+    }
+}

--- a/app/Models/AccountModel.php
+++ b/app/Models/AccountModel.php
@@ -82,4 +82,9 @@ class AccountModel extends Model
             ->join('Admin', 'Admin.user_id = Account.user_id')
             ->findAll();
     }
+
+    public function changePasswordHash(int $userId, string $newPasswordHash): void
+    {
+        $this->update($userId, ['password' => $newPasswordHash]);
+    }
 }

--- a/app/Models/PasswordResetTokenModel.php
+++ b/app/Models/PasswordResetTokenModel.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+class PasswordResetTokenModel extends Model
+{
+    protected $table = 'PasswordResetToken';
+    protected $primaryKey = 'token';
+    protected $allowedFields = ['token', 'user_id', 'expires_at'];
+    protected array $casts = [
+        'user_id' => 'int',
+    ];
+    protected $useTimestamps = true;
+
+    public function store(string $token, int $userId, string $expiresAt): void
+    {
+        $this->insert([
+            'token' => $token,
+            'user_id' => $userId,
+            'expires_at' => $expiresAt,
+        ]);
+    }
+
+    public function deleteTokensOfUser(int $userId): void
+    {
+        $this->where('user_id', $userId)->delete();
+    }
+
+    public function deleteExpiredTokens(): void
+    {
+        $this->where('expires_at <', date('Y-m-d H:i:s'))->delete();
+    }
+
+    public function get(string $token): ?array
+    {
+        return $this->where('token', $token)->first();
+    }
+}

--- a/app/Views/email/account/forgot_password.php
+++ b/app/Views/email/account/forgot_password.php
@@ -1,0 +1,11 @@
+Liebe:r <?= esc($username) ?>,
+
+du hast dein Passwort für die Tech Stream Conference vergessen? Kein Problem! Klicke auf den folgenden Link, um ein neues Passwort festzulegen:
+
+<?= $resetPasswordLink ?>
+
+
+Beachte, dass der Link nur 24 Stunden gültig ist.
+
+Viele Grüße,
+das Tech Stream Conference Team

--- a/app/Views/email/account/password_reset.php
+++ b/app/Views/email/account/password_reset.php
@@ -1,0 +1,6 @@
+Liebe:r <?= esc($username) ?>,
+
+es wurde ein neues Passwort für deinen Account bei der Tech Stream Conference erstellt. Du warst das nicht? Dann kontaktiere uns bitte umgehend.
+
+Viele Grüße,
+das Tech Stream Conference Team

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "slack": "https://codeigniterchat.slack.com"
     },
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "codeigniter4/framework": "^4.0",
       "ext-mbstring": "*"
     },

--- a/requests/account/forgot_password.http
+++ b/requests/account/forgot_password.http
@@ -1,0 +1,7 @@
+POST localhost:8080/api/account/forgot-password
+
+{
+  "username_or_email": "coder2k"
+}
+
+###

--- a/requests/account/set_new_password.http
+++ b/requests/account/set_new_password.http
@@ -1,0 +1,8 @@
+POST localhost:8080/api/account/reset-password
+
+{
+  "token": "ed9afa9f3fbb1aaa766531683ff58929efada724f880e67269aab43e71eec425091adf906702c68f8fd649ff45df9dbc805f0591e8b7bf8018e7bbc875ebbe82",
+  "new_password": "Coder2k123!"
+}
+
+###


### PR DESCRIPTION
This PR introduces two new endpoints:
- `api/account/forgot-password`: requires the `username_or_email`, sends an email to the user with a randomly generated token to set a new password
- `account/reset-password`: requires the `token` and `new_password`, sets the password for the user to whom the token corresponds, sends a notification email

Tokens are valid for 24 hours. Expired tokens are deleted when any user tries to log in and when a user tries to use a token. This should complete the backend part of the [login use case](https://github.com/TechStreamConference/entity-relationship-model/blob/9f42c1171a97f18e7e13cf05f12e3e790564f3f3/system-tests/login.png).