### PR TITLE
allow registering for an existing user using a predefined token

### DIFF
--- a/app/Controllers/Account.php
+++ b/app/Controllers/Account.php
@@ -21,7 +21,7 @@ class Account extends BaseController
     ];
 
     const VERIFICATION_RULES = [
-        'token' => 'required|trim',
+        'token' => 'required|trim|alpha_numeric|max_length[128]',
     ];
 
     const FORGOT_PASSWORD_RULES = [

--- a/app/Controllers/Account.php
+++ b/app/Controllers/Account.php
@@ -4,6 +4,7 @@ namespace App\Controllers;
 
 use App\Helpers\EmailHelper;
 use App\Models\AccountModel;
+use App\Models\ConnectedRegistrationTokenModel;
 use App\Models\PasswordResetTokenModel;
 use App\Models\RolesModel;
 use App\Models\UserModel;
@@ -18,6 +19,7 @@ class Account extends BaseController
         'username' => 'required|trim|alpha_dash|min_length[3]|max_length[30]',
         'password' => 'required|valid_password',
         'email' => 'required|trim|valid_email|max_length[320]',
+        'token' => 'permit_empty|trim|alpha_numeric|max_length[128]',
     ];
 
     const VERIFICATION_RULES = [
@@ -51,10 +53,29 @@ class Account extends BaseController
         $passwordHash = password_hash($validData['password'], PASSWORD_DEFAULT);
         $email = $validData['email'];
 
-        $userId = $userModel->createUser();
+        // If a token was provided, we won't create a new user during this registration, but
+        // instead connect the new account to an existing user. This is used for speakers
+        // that have already been created by the admins, before the site goes live.
+        $token = $validData['token'] ?? null;
+        $isConnectedRegistration = $token !== null;
+        if (!$isConnectedRegistration) {
+            $userId = $userModel->createUser();
+        } else {
+            // Check which user the provided token belongs to.
+            $connectedRegistrationTokenModel = model(ConnectedRegistrationTokenModel::class);
+            $entry = $connectedRegistrationTokenModel->get($token);
+            if ($entry === null) {
+                return $this->response->setJSON(['error' => 'TOKEN_NOT_FOUND'])->setStatusCode(404);
+            }
+            $userId = $entry['user_id'];
+            // We will delete the token further down, after everything else was successful.
+        }
+
         if ($accountModel->createAccount($userId, $username, $passwordHash, $email) === false) {
             // Username or email already taken.
-            $userModel->deleteUser($userId);
+            if (!$isConnectedRegistration) {
+                $userModel->deleteUser($userId);
+            }
             return $this->response->setJSON(['error' => 'USERNAME_OR_EMAIL_ALREADY_TAKEN'])->setStatusCode(400);
         }
 
@@ -63,7 +84,9 @@ class Account extends BaseController
             // This could only happen if the token is already in use, or if the random generator
             // fails. So, this should never happen. But if it does, we need to clean up the database.
             $accountModel->deleteAccount($userId);
-            $userModel->deleteUser($userId);
+            if (!$isConnectedRegistration) {
+                $userModel->deleteUser($userId);
+            }
             return $this->response->setStatusCode(500);
         }
 
@@ -92,6 +115,10 @@ class Account extends BaseController
                 ]
             )
         );
+
+        if ($isConnectedRegistration) {
+            $connectedRegistrationTokenModel->deleteToken($token);
+        }
 
         return $this->response->setJSON(['message' => 'success'])->setStatusCode(201);
     }

--- a/app/Database/Migrations/2025-01-06-171157_AddConnectedRegistrationToken.php
+++ b/app/Database/Migrations/2025-01-06-171157_AddConnectedRegistrationToken.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class AddConnectedRegistrationToken extends Migration
+{
+    public function up()
+    {
+        $this->forge->addField([
+            'token' => [
+                'type' => 'VARCHAR',
+                'constraint' => 255,
+            ],
+            'user_id' => [
+                'type' => 'INT',
+                'unsigned' => true,
+            ],
+            'created_at' => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+            'updated_at' => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+            'deleted_at' => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+        ]);
+        $this->forge->addPrimaryKey('token');
+        $this->forge->addForeignKey('user_id', 'User', 'id');
+        $this->forge->createTable('ConnectedRegistrationToken');
+    }
+
+    public function down()
+    {
+        $this->forge->dropTable('ConnectedRegistrationToken');
+    }
+}

--- a/app/Database/Seeds/ConnectedRegistrationTokenSeeder.php
+++ b/app/Database/Seeds/ConnectedRegistrationTokenSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Database\Seeds;
+
+use CodeIgniter\Database\Seeder;
+
+class ConnectedRegistrationTokenSeeder extends Seeder
+{
+    public function run()
+    {
+        // Token for a connected registration for the user that corresponds
+        // to speaker "codingPurpurTentakel".
+        $this->db->table('ConnectedRegistrationToken')->insert([
+            'token' => 'd9f05f981302c5d8dcdd165cbd6b627ed33677207614e6fd6a1e9a68def5b6fd4180332e00475421e3bb7b6810bb2d1e6b6fa592cd613bee1b215b304a8a7b1a',
+            'user_id' => 4,
+        ]);
+    }
+}

--- a/app/Database/Seeds/MainSeeder.php
+++ b/app/Database/Seeds/MainSeeder.php
@@ -22,5 +22,6 @@ class MainSeeder extends Seeder
         $this->call('TalkHasTagSeeder');
         $this->call('AdminSeeder');
         $this->call('GlobalsSeeder');
+        $this->call('ConnectedRegistrationTokenSeeder');
     }
 }

--- a/app/Models/ConnectedRegistrationTokenModel.php
+++ b/app/Models/ConnectedRegistrationTokenModel.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use CodeIgniter\Model;
+
+class ConnectedRegistrationTokenModel extends Model
+{
+    protected $table = 'ConnectedRegistrationToken';
+    protected $allowedFields = [
+        'user_id',
+        'token',
+    ];
+    protected $useTimestamps = true;
+    protected array $casts = [
+        'user_id' => 'int',
+    ];
+
+    public function get(string $token): ?array
+    {
+        return $this->where('token', $token)->first();
+    }
+
+    public function deleteToken(string $token): void
+    {
+        $this->where('token', $token)->delete();
+    }
+}

--- a/requests/account/create_connected_account.http
+++ b/requests/account/create_connected_account.http
@@ -1,0 +1,9 @@
+POST localhost:8080/api/account/register
+
+{
+  "username": "codingPurpurTentakel",
+  "email": "tentakel@test-conf.de",
+  "password": "CodingPurpurTentakel123!",
+  "token": "d9f05f981302c5d8dcdd165cbd6b627ed33677207614e6fd6a1e9a68def5b6fd4180332e00475421e3bb7b6810bb2d1e6b6fa592cd613bee1b215b304a8a7b1a"
+}
+###

--- a/tests/App/Controllers/AccountTest.php
+++ b/tests/App/Controllers/AccountTest.php
@@ -306,6 +306,28 @@ class AccountTest extends CIUnitTestCase
         $result->assertJSONExact(['error' => 'USERNAME_OR_EMAIL_ALREADY_TAKEN']);
     }
 
+    function testRegister_ExistingUser_ValidToken_Returns201()
+    {
+        $result = $this->withBodyFormat('json')->post('account/register', [
+            'username' => 'codingPurpurTentakel',
+            'password' => 'CodingPurpurTentakel123!',
+            'email' => 'tentakel@test-conf.de',
+            'token' => 'd9f05f981302c5d8dcdd165cbd6b627ed33677207614e6fd6a1e9a68def5b6fd4180332e00475421e3bb7b6810bb2d1e6b6fa592cd613bee1b215b304a8a7b1a',
+        ]);
+        $result->assertStatus(201);
+    }
+
+    function testRegister_ExistingUser_InvalidToken_Returns404()
+    {
+        $result = $this->withBodyFormat('json')->post('account/register', [
+            'username' => 'codingPurpurTentakel',
+            'password' => 'CodingPurpurTentakel123!',
+            'email' => 'tentakel@test-conf.de',
+            'token' => '123',
+        ]);
+        $result->assertStatus(404);
+    }
+
     // *************************************
     // * usernameExists()
     // *************************************


### PR DESCRIPTION
This PR enhances the `api/account/register` endpoint so that it's now possible to pass an additional `token`. If that token matches a token stored in the new `ConnectedRegistrationToken` table, the newly created account will be connected to the user that's associated with that token (instead of creating a new user). This makes it possible to let users register with their custom username/email/password and still have access to existing speaker (or team member) entries that we have created before.

If a token is provided, but it cannot be found in the database, registration fails.