### PR TITLE
Time Slots

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -9,6 +9,7 @@ use App\Controllers\Image;
 use App\Controllers\HealthCheck;
 use App\Controllers\SpeakerDashboard;
 use App\Controllers\TeamMemberDashboard;
+use App\Controllers\TimeSlot;
 use App\Filters\AdminAuthFilter;
 use App\Filters\AuthFilter;
 use App\Filters\SpeakerAuthFilter;
@@ -53,6 +54,9 @@ $routes->put('dashboard/admin/approval/team-member/(:num)/request-changes', [App
 $routes->get('dashboard/admin/approval/social-media-link', [Approval::class, 'getPendingSocialMediaLinks'], ['filter' => AdminAuthFilter::class]);
 $routes->put('dashboard/admin/approval/social-media-link/(:num)', [Approval::class, 'approveSocialMediaLink'], ['filter' => AdminAuthFilter::class]);
 $routes->put('dashboard/admin/approval/social-media-link/(:num)/request-changes', [Approval::class, 'requestChangesForSocialMediaLink'], ['filter' => AdminAuthFilter::class]);
+
+$routes->get('dashboard/admin/time-slots/(:num)', [TimeSlot::class, 'get'], ['filter' => AdminAuthFilter::class]);
+$routes->post('dashboard/admin/time-slots/(:num)', [TimeSlot::class, 'create_or_replace'], ['filter' => AdminAuthFilter::class]);
 
 $routes->get('dashboard/speaker/all-events', [SpeakerDashboard::class, 'getAll'], ['filter' => SpeakerAuthFilter::class]);
 $routes->get('dashboard/speaker/event/(:num)', [SpeakerDashboard::class, 'get'], ['filter' => SpeakerAuthFilter::class]);

--- a/app/Controllers/TimeSlot.php
+++ b/app/Controllers/TimeSlot.php
@@ -65,9 +65,7 @@ class TimeSlot extends BaseController
         $timeSlotModel = model(TimeSlotModel::class);
         $timeSlots = $timeSlotModel->getByEventId($eventId);
         $timeSlotsArray = array_map(
-            function ($timeSlot) {
-                return $timeSlot->toArray();
-            },
+            fn($timeSlot) => $timeSlot->toArray(),
             $timeSlots,
         );
         return $this->response->setJSON($timeSlotsArray);

--- a/app/Controllers/TimeSlot.php
+++ b/app/Controllers/TimeSlot.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Controllers;
+
+use App\Helpers\TimeSlotData;
+use App\Models\EventModel;
+use App\Models\TimeSlotModel;
+use CodeIgniter\HTTP\ResponseInterface;
+
+class TimeSlot extends BaseController
+{
+    const TIME_SLOT_RULES = [
+        'time_slots.*.start_time' => 'required|valid_date[Y-m-d H:i:s]',
+        'time_slots.*.duration' => 'required|is_natural_no_zero',
+    ];
+
+    public function create_or_replace(int $eventId): ResponseInterface
+    {
+        $data = $this->request->getJSON(true);
+
+        if (!$this->validateData($data, self::TIME_SLOT_RULES)) {
+            return $this->response->setJSON($this->validator->getErrors())->setStatusCode(400);
+        }
+
+        $validData = $this->validator->getValidated();
+
+        $eventModel = model(EventModel::class);
+        $event = $eventModel->get($eventId);
+        if ($event === null) {
+            return $this->response->setJSON(['error' => 'EVENT_NOT_FOUND'])->setStatusCode(404);
+        }
+
+        $timeSlotModel = model(TimeSlotModel::class);
+
+        $timeSlots = array_map(
+            function (array $slot) use ($eventId) {
+                return TimeSlotData::make(
+                    $eventId,
+                    $slot['start_time'],
+                    $slot['duration'],
+                );
+            },
+            $validData['time_slots'],
+        );
+
+        $validationResult = $this->areTimeSlotsValid($timeSlots, $event);
+        if ($validationResult !== true) {
+            return $validationResult;
+        }
+
+        $timeSlotModel->deleteAllOfEvent($eventId);
+        if (!$timeSlotModel->store($timeSlots)) {
+            return $this->response->setJSON(['error' => 'FAILED_TO_STORE_TIME_SLOTS'])->setStatusCode(500);
+        }
+        return $this->response->setStatusCode(204);
+    }
+
+    public function get(int $eventId): ResponseInterface
+    {
+        $eventModel = model(EventModel::class);
+        if (!$eventModel->doesExist($eventId)) {
+            return $this->response->setJSON(['error' => 'EVENT_NOT_FOUND'])->setStatusCode(404);
+        }
+
+        $timeSlotModel = model(TimeSlotModel::class);
+        $timeSlots = $timeSlotModel->getByEventId($eventId);
+        $timeSlotsArray = array_map(
+            function ($timeSlot) {
+                return $timeSlot->toArray();
+            },
+            $timeSlots,
+        );
+        return $this->response->setJSON($timeSlotsArray);
+    }
+
+    /**
+     * Checks whether the given time slots are valid (i.e., they don't overlap with each other and they don't
+     * exceed the event's duration).
+     * @param TimeSlotData[] $timeSlots The time slots to check.
+     * @param array $event The event data.
+     * @return true|ResponseInterface True if the time slots are valid, a ResponseInterface object otherwise.
+     */
+    private function areTimeSlotsValid(array $timeSlots, array $event): true|ResponseInterface
+    {
+        // Do they overlap?
+        if ($this->doOverlap($timeSlots)) {
+            return $this->response->setJSON(['error' => 'TIME_SLOTS_OVERLAP'])->setStatusCode(400);
+        }
+
+        // Do they exceed the event's duration?
+        $eventStart = strtotime($event['start_date']);
+        $eventEnd = strtotime($event['end_date'] . " + 1 day - 1 second");
+        foreach ($timeSlots as $timeSlot) {
+            if (!$this->isWithinTimeFrame($timeSlot, $eventStart, $eventEnd)) {
+                return $this->response->setJSON(['error' => 'TIME_SLOT_OUTSIDE_EVENT_DURATION'])->setStatusCode(400);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks whether the given time slots overlap with each other.
+     * @param TimeSlotData[] $timeSlots
+     * @return bool True if the time slots overlap, false otherwise.
+     */
+    private function doOverlap(array $timeSlots): bool
+    {
+        // This has quadratic runtime complexity, but it's fine because the number of time slots is small.
+        $n = count($timeSlots);
+        for ($i = 0; $i < $n - 1; ++$i) {
+            for ($j = $i + 1; $j < $n; ++$j) {
+                if ($this->overlaps($timeSlots[$i], $timeSlots[$j])) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private function overlaps(TimeSlotData $a, TimeSlotData $b): bool
+    {
+        $startA = strtotime($a->startTime);
+        $endA = $startA + $a->duration * 60;
+        $startB = strtotime($b->startTime);
+        $endB = $startB + $b->duration * 60;
+        return $startA < $endB && $startB < $endA;
+    }
+
+    private function isWithinTimeFrame(
+        TimeSlotData $timeSlot,
+        int          $start,
+        int          $end,
+    ): bool
+    {
+        $timeSlotStart = strtotime($timeSlot->startTime);
+        $timeSlotEnd = strtotime($timeSlot->startTime . "+ $timeSlot->duration minutes");
+
+        return $timeSlotStart >= $start && $timeSlotEnd <= $end;
+    }
+}

--- a/app/Database/Migrations/2025-01-07-123201_AddTimeSlot.php
+++ b/app/Database/Migrations/2025-01-07-123201_AddTimeSlot.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class AddTimeSlot extends Migration
+{
+    public function up()
+    {
+        $this->forge->addField([
+            'id' => [
+                'type' => 'INT',
+                'unsigned' => true,
+                'auto_increment' => true,
+            ],
+            'event_id' => [
+                'type' => 'INT',
+                'unsigned' => true,
+            ],
+            'start_time' => [
+                'type' => 'DATETIME',
+            ],
+            'duration' => [
+                'type' => 'INT',
+                'unsigned' => true,
+            ],
+            'created_at' => [
+                'type' => 'DATETIME',
+            ],
+            'updated_at' => [
+                'type' => 'DATETIME',
+            ],
+            'deleted_at' => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
+        ]);
+        $this->forge->addPrimaryKey('id');
+        $this->forge->addForeignKey('event_id', 'Event', 'id');
+        $this->forge->createTable('TimeSlot');
+    }
+
+    public function down()
+    {
+        $this->forge->dropTable('TimeSlot');
+    }
+}

--- a/app/Database/Migrations/2025-01-07-123201_AddTimeSlot.php
+++ b/app/Database/Migrations/2025-01-07-123201_AddTimeSlot.php
@@ -25,6 +25,9 @@ class AddTimeSlot extends Migration
                 'type' => 'INT',
                 'unsigned' => true,
             ],
+            'is_special' => [
+                'type' => 'BOOLEAN',
+            ],
             'created_at' => [
                 'type' => 'DATETIME',
             ],

--- a/app/Helpers/TimeSlotData.php
+++ b/app/Helpers/TimeSlotData.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Helpers;
+
+/**
+ * Represents the data of a row in the TimeSlot table.
+ */
+class TimeSlotData
+{
+    public ?int $id;
+    public int $eventId;
+    public string $startTime;
+    public int $duration;
+
+    private function __construct(
+        ?int   $id,
+        int    $eventId,
+        string $startTime,
+        int    $duration
+    )
+    {
+        $this->id = $id;
+        $this->eventId = $eventId;
+        $this->startTime = $startTime;
+        $this->duration = $duration;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'event_id' => $this->eventId,
+            'start_time' => $this->startTime,
+            'duration' => $this->duration,
+        ];
+    }
+
+    public function toArrayWithoutId(): array
+    {
+        return [
+            'event_id' => $this->eventId,
+            'start_time' => $this->startTime,
+            'duration' => $this->duration,
+        ];
+    }
+
+    public static function fromArray(array $array): TimeSlotData
+    {
+        return new TimeSlotData(
+            $array['id'] ?? null,
+            $array['event_id'],
+            $array['start_time'],
+            $array['duration']
+        );
+    }
+
+    public static function make(
+        int    $eventId,
+        string $startTime,
+        int    $duration
+    ): TimeSlotData
+    {
+        return new TimeSlotData(
+            null,
+            $eventId,
+            $startTime,
+            $duration
+        );
+    }
+}

--- a/app/Models/EventModel.php
+++ b/app/Models/EventModel.php
@@ -67,7 +67,7 @@ class EventModel extends Model
     public function getLatestPublished(): array|null
     {
         return $this
-            ->select('id, title, subtitle, start_date, end_date, discord_url, twitch_url, presskit_url, trailer_youtube_id, description_headline, description, call_for_papers_start, call_for_papers_end')
+            ->select('id, title, subtitle, start_date, end_date, discord_url, twitch_url, presskit_url, trailer_youtube_id, description_headline, description, schedule_visible_from, publish_date, call_for_papers_start, call_for_papers_end')
             ->where('publish_date <=', date('Y-m-d H:i:s'))
             ->orderBy('start_date', 'DESC')
             ->first();

--- a/app/Models/EventModel.php
+++ b/app/Models/EventModel.php
@@ -73,6 +73,19 @@ class EventModel extends Model
             ->first();
     }
 
+    public function get(int $eventId): array|null
+    {
+        return $this
+            ->select('id, title, subtitle, start_date, end_date, discord_url, twitch_url, presskit_url, trailer_youtube_id, description_headline, description, schedule_visible_from, publish_date, call_for_papers_start, call_for_papers_end')
+            ->where('id', $eventId)
+            ->first();
+    }
+
+    public function doesExist(int $eventId): bool
+    {
+        return $this->where('id', $eventId)->countAllResults() > 0;
+    }
+
     public function updateEvent(
         int     $eventId,
         string  $title,

--- a/app/Models/TimeSlotModel.php
+++ b/app/Models/TimeSlotModel.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Models;
+
+use App\Helpers\TimeSlotData;
+use CodeIgniter\Model;
+
+class TimeSlotModel extends Model
+{
+    protected $table = 'TimeSlot';
+    protected $allowedFields = [
+        'event_id',
+        'start_time',
+        'duration',
+        'created_at',
+        'updated_at',
+        'deleted_at',
+    ];
+    protected $useTimestamps = true;
+    protected array $casts = [
+        'id' => 'int',
+        'event_id' => 'int',
+        'duration' => 'int',
+    ];
+
+    /**
+     * Stores time slots for an event. The $id property of each TimeSlot object
+     * is ignored.
+     *
+     * @param TimeSlotData[] $timeSlots
+     * @return bool True if the operation was successful, false otherwise.
+     */
+    public function store(array $timeSlots): bool
+    {
+        $data = array_map(
+            fn($timeSlot) => $timeSlot->toArrayWithoutId(), // Ignore IDs.
+            $timeSlots,
+        );
+
+        // insertBatch() returns the number of rows inserted (int) or false on failure
+        return $this->insertBatch($data) !== false;
+    }
+
+    /**
+     * Deletes all time slots for an event (if any).
+     * @param int $eventId
+     */
+    public function deleteAllOfEvent(int $eventId): void
+    {
+        $this->where('event_id', $eventId)->delete();
+    }
+
+    /**
+     * Gets all time slots for an event.
+     * @param int $eventId
+     * @return TimeSlotData[] An array of TimeSlot objects.
+     */
+    public function getByEventId(int $eventId): array
+    {
+        return array_map(
+            TimeSlotData::fromArray(...),
+            $this->where('event_id', $eventId)->orderBy('start_time')->findAll(),
+        );
+    }
+}

--- a/requests/time_slots/create_or_replace_time_slots.http
+++ b/requests/time_slots/create_or_replace_time_slots.http
@@ -1,0 +1,51 @@
+POST http://localhost:8080/api/account/login
+
+{
+  "username_or_email": "coder2k",
+  "password": "password"
+}
+
+###
+
+POST localhost:8080/api/dashboard/admin/time-slots/1
+
+{
+    "time_slots": [
+        {
+            "start_time": "2024-06-22 13:00:00",
+            "duration": 45
+        },
+        {
+            "start_time": "2024-06-22 14:00:00",
+            "duration": 45
+        },
+        {
+            "start_time": "2024-06-22 15:00:00",
+            "duration": 30
+        },
+        {
+            "start_time": "2024-06-22 19:30:00",
+            "duration": 60
+        },
+        {
+            "start_time": "2024-06-23 11:00:00",
+            "duration": 45
+        },
+        {
+            "start_time": "2024-06-23 12:00:00",
+            "duration": 45
+        },
+        {
+            "start_time": "2024-06-23 13:00:00",
+            "duration": 45
+        },
+        {
+            "start_time": "2024-06-23 18:30:00",
+            "duration": 45
+        },
+        {
+            "start_time": "2024-06-23 19:30:00",
+            "duration": 60
+        }
+    ]
+}

--- a/requests/time_slots/get_time_slots.http
+++ b/requests/time_slots/get_time_slots.http
@@ -1,0 +1,10 @@
+POST http://localhost:8080/api/account/login
+
+{
+  "username_or_email": "coder2k",
+  "password": "password"
+}
+
+###
+
+GET localhost:8080/api/dashboard/admin/time-slots/1


### PR DESCRIPTION
This PR adds two new endpoints:
- `GET api/dashboard/admin/time-slots/(:num)`, where `num` is an event id: returns a list of all time slots that correspond to the specified event, e. g.
    ```json5
    [
      {
        "id": 91,
        "event_id": 1,
        "start_time": "2024-06-22 13:00:00",
        "duration": 45
      },
      {
        "id": 92,
        "event_id": 1,
        "start_time": "2024-06-22 14:00:00",
        "duration": 45
      },
      // more time slots...
    ]
    ```
    Possible errors:
    - `EVENT_NOT_FOUND` (404)
    
    Otherwise returns status 200.
- `POST api/dashboard/admin/time-slots/(:num)`, where `num` is an event id: Takes JSON data of the following form:
    ```json5
    {
        "time_slots": [
            {
                "start_time": "2024-06-22 13:00:00",
                "duration": 45
            },
            {
                "start_time": "2024-06-22 14:00:00",
                "duration": 45
            },
            // more time slots...
        ]
    }
    ```
    The transmitted data is checked (all time slots must be during the specified event, slots must not overlap each other) and then stored.

    **WARNING:** When storing new time slots for an event, all existing time slots of the event are deleted! This cannot be undone!

    Possible errors:
    - invalid JSON (400)
    - `EVENT_NOT_FOUND` (404)
    - `TIME_SLOTS_OVERLAP` (400)
    - `TIME_SLOT_OUTSIDE_EVENT_DURATION` (400)
    - `FAILED_TO_STORE_TIME_SLOTS` (500, should never happen)
   
    Otherwise returns status 204.