### PR TITLE
Allow changing the username, email address, or password

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -30,6 +30,7 @@ $routes->post('account/reset-password', [Account::class, 'resetPassword']);
 $routes->post('account/login', [Account::class, 'login']);
 $routes->post('account/logout', [Account::class, 'logout']);
 $routes->post('account/verify', [Account::class, 'verify']);
+$routes->put('account/change-username', [Account::class, 'changeUsername'], ['filter' => AuthFilter::class]);
 $routes->get('images/(:segment)', [Image::class, 'get']);
 $routes->get('events', [Event::class, 'get']);
 $routes->get('events/(:num)', [Event::class, 'get']);

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -32,6 +32,7 @@ $routes->post('account/logout', [Account::class, 'logout']);
 $routes->post('account/verify', [Account::class, 'verify']);
 $routes->put('account/change-username', [Account::class, 'changeUsername'], ['filter' => AuthFilter::class]);
 $routes->put('account/change-password', [Account::class, 'changePassword'], ['filter' => AuthFilter::class]);
+$routes->put('account/change-email', [Account::class, 'changeEmail'], ['filter' => AuthFilter::class]);
 $routes->get('images/(:segment)', [Image::class, 'get']);
 $routes->get('events', [Event::class, 'get']);
 $routes->get('events/(:num)', [Event::class, 'get']);

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -31,6 +31,7 @@ $routes->post('account/login', [Account::class, 'login']);
 $routes->post('account/logout', [Account::class, 'logout']);
 $routes->post('account/verify', [Account::class, 'verify']);
 $routes->put('account/change-username', [Account::class, 'changeUsername'], ['filter' => AuthFilter::class]);
+$routes->put('account/change-password', [Account::class, 'changePassword'], ['filter' => AuthFilter::class]);
 $routes->get('images/(:segment)', [Image::class, 'get']);
 $routes->get('events', [Event::class, 'get']);
 $routes->get('events/(:num)', [Event::class, 'get']);

--- a/app/Controllers/Account.php
+++ b/app/Controllers/Account.php
@@ -227,7 +227,7 @@ class Account extends BaseController
             return $this->response->setStatusCode(500);
         }
 
-        $accountModel->changePasswordHash($entry['user_id'], password_hash($newPassword, PASSWORD_DEFAULT));
+        $accountModel->changePassword($entry['user_id'], $newPassword);
 
         // Delete the used token as well as all other tokens of the same user that may exist.
         $passwordResetTokenModel->deleteTokensOfUser($entry['user_id']);

--- a/app/Controllers/Account.php
+++ b/app/Controllers/Account.php
@@ -15,10 +15,14 @@ use Random\RandomException;
 
 class Account extends BaseController
 {
+    const USERNAME_RULE = 'required|trim|alpha_dash|min_length[3]|max_length[30]';
+    const PASSWORD_RULE = 'required|valid_password';
+    const EMAIL_RULE = 'required|trim|valid_email|max_length[320]';
+
     const REGISTER_RULES = [
-        'username' => 'required|trim|alpha_dash|min_length[3]|max_length[30]',
-        'password' => 'required|valid_password',
-        'email' => 'required|trim|valid_email|max_length[320]',
+        'username' => self::USERNAME_RULE,
+        'password' => self::PASSWORD_RULE,
+        'email' => self::EMAIL_RULE,
         'token' => 'permit_empty|trim|alpha_numeric|max_length[128]',
     ];
 
@@ -32,7 +36,7 @@ class Account extends BaseController
 
     const RESET_PASSWORD_RULES = [
         'token' => 'required|trim',
-        'new_password' => 'required|valid_password',
+        'new_password' => self::PASSWORD_RULE,
     ];
 
     public function register()

--- a/app/Controllers/Account.php
+++ b/app/Controllers/Account.php
@@ -388,7 +388,22 @@ class Account extends BaseController
             return $this->response->setJSON(['error' => 'USERNAME_ALREADY_TAKEN'])->setStatusCode(400);
         }
 
+        $account = $accountModel->get($userId);
+        $oldUsername = $account['username'];
+
         $accountModel->changeUsername($userId, $username);
+
+        EmailHelper::sendToAdmins(
+            subject: "Benutzername geändert",
+            message: view(
+                'email/admin/username_changed',
+                [
+                    'oldUsername' => $oldUsername,
+                    'newUsername' => $username,
+                ]
+            )
+        );
+
         return $this->response->setJSON(['message' => 'USERNAME_CHANGED']);
     }
 

--- a/app/Database/Migrations/2024-12-08-132335_AddVerificationToken.php
+++ b/app/Database/Migrations/2024-12-08-132335_AddVerificationToken.php
@@ -20,6 +20,11 @@ class AddVerificationToken extends Migration
             'expires_at' => [
                 'type' => 'DATETIME',
             ],
+            'new_email' => [
+                'type' => 'VARCHAR',
+                'constraint' => 320,
+                'null' => true,
+            ],
             'created_at' => [
                 'type' => 'DATETIME',
                 'null' => true,

--- a/app/Database/Seeds/AccountSeeder.php
+++ b/app/Database/Seeds/AccountSeeder.php
@@ -14,7 +14,7 @@ class AccountSeeder extends Seeder
                 'email' => 'coder2k@test-conf.de',
                 'username' => 'coder2k',
                 'is_verified' => true,
-                'password' => password_hash('password', null),
+                'password' => password_hash('Coder2k123!', null),
                 'created_at' => date('2024-08-17 13:00:00'),
                 'updated_at' => date('2024-08-17 13:00:00'),
             ]
@@ -25,7 +25,7 @@ class AccountSeeder extends Seeder
                 'email' => 'gyrosgeier@geier.horst',
                 'username' => 'Gyros Geier',
                 'is_verified' => true,
-                'password' => password_hash('horst', null),
+                'password' => password_hash('GyrosGeier123!', null),
                 'created_at' => date('2024-08-17 14:00:00'),
                 'updated_at' => date('2024-08-17 14:00:00'),
             ]

--- a/app/Models/AccountModel.php
+++ b/app/Models/AccountModel.php
@@ -87,4 +87,9 @@ class AccountModel extends Model
     {
         $this->update($userId, ['password' => $newPasswordHash]);
     }
+
+    public function changeUsername(int $userId, string $newUsername): void
+    {
+        $this->update($userId, ['username' => $newUsername]);
+    }
 }

--- a/app/Models/AccountModel.php
+++ b/app/Models/AccountModel.php
@@ -12,7 +12,13 @@ class AccountModel extends Model
     // according to the docs, the primary key should never be part of the allowedFields
     // array, but it doesn't seem to work without having it in there (the reason could be
     // that it is also a foreign key)
-    protected $allowedFields = ['user_id', 'email', 'is_verified', 'username', 'password', 'password_change_required'];
+    protected $allowedFields = [
+        'user_id',
+        'email',
+        'is_verified',
+        'username',
+        'password_change_required'
+    ];
     protected array $casts = [
         'user_id' => 'int',
         'is_verified' => 'bool',
@@ -73,6 +79,12 @@ class AccountModel extends Model
             ->select('username, email')
             ->where('user_id', $userId)
             ->first();
+    }
+
+    public function checkPassword(int $userId, string $password): bool
+    {
+        $account = $this->find($userId);
+        return password_verify($password, $account['password']);
     }
 
     public function getAdmins(): array

--- a/app/Models/AccountModel.php
+++ b/app/Models/AccountModel.php
@@ -17,7 +17,8 @@ class AccountModel extends Model
         'email',
         'is_verified',
         'username',
-        'password_change_required'
+        'password',
+        'password_change_required',
     ];
     protected array $casts = [
         'user_id' => 'int',
@@ -40,7 +41,12 @@ class AccountModel extends Model
                 ->countAllResults() > 0;
     }
 
-    public function createAccount(int $userId, string $username, string $passwordHash, string $email): bool
+    public function createAccount(
+        int    $userId,
+        string $username,
+        string $passwordHash,
+        string $email
+    ): bool
     {
         try {
             $this->insert([
@@ -68,6 +74,7 @@ class AccountModel extends Model
     public function getAccountByUsernameOrEmail(string $usernameOrEmail): array|null
     {
         return $this
+            ->select('user_id, username, email, is_verified, password_change_required')
             ->where('username', $usernameOrEmail)
             ->orWhere('email', $usernameOrEmail)
             ->first();

--- a/app/Models/AccountModel.php
+++ b/app/Models/AccountModel.php
@@ -112,4 +112,9 @@ class AccountModel extends Model
     {
         $this->update($userId, ['username' => $newUsername]);
     }
+
+    public function changeEmail(int $userId, string $newEmail): void
+    {
+        $this->update($userId, ['email' => $newEmail]);
+    }
 }

--- a/app/Models/AccountModel.php
+++ b/app/Models/AccountModel.php
@@ -95,8 +95,9 @@ class AccountModel extends Model
             ->findAll();
     }
 
-    public function changePasswordHash(int $userId, string $newPasswordHash): void
+    public function changePassword(int $userId, string $newPassword): void
     {
+        $newPasswordHash = password_hash($newPassword, PASSWORD_DEFAULT);
         $this->update($userId, ['password' => $newPasswordHash]);
     }
 

--- a/app/Models/VerificationTokenModel.php
+++ b/app/Models/VerificationTokenModel.php
@@ -11,6 +11,7 @@ class VerificationTokenModel extends Model
     protected $allowedFields = [
         'user_id',
         'token',
+        'new_email',
         'expires_at',
         'created_at',
         'updated_at',
@@ -27,13 +28,19 @@ class VerificationTokenModel extends Model
             ->first();
     }
 
-    public function store(string $token, int $userId, string $expiresAt): bool
+    public function store(
+        string  $token,
+        int     $userId,
+        string  $expiresAt,
+        ?string $newEmail,
+    ): bool
     {
         try {
             $this->insert([
                 'token' => $token,
                 'user_id' => $userId,
                 'expires_at' => $expiresAt,
+                'new_email' => $newEmail,
             ]);
             return true;
         } catch (DatabaseException) {

--- a/app/Views/email/admin/username_changed.php
+++ b/app/Views/email/admin/username_changed.php
@@ -1,0 +1,6 @@
+Liebe:r Tech Stream Conference Admin,
+
+<?= esc($oldUsername) ?> hat sich in <?= esc($newUsername) ?> umbenannt.
+
+Viele Grüße,
+das Tech Stream Conference Team

--- a/requests/account/change_email.http
+++ b/requests/account/change_email.http
@@ -1,0 +1,15 @@
+POST http://localhost:8080/api/account/login
+
+{
+  "username_or_email": "coder2k",
+  "password": "Coder2k123!"
+}
+
+###
+
+PUT localhost:8080/api/account/change-email
+
+{
+    "password": "Coder2k123!",
+    "email": "coder@2k.com"
+}

--- a/requests/account/change_password.http
+++ b/requests/account/change_password.http
@@ -1,0 +1,15 @@
+POST http://localhost:8080/api/account/login
+
+{
+  "username_or_email": "coder2k",
+  "password": "Coder2k123!"
+}
+
+###
+
+PUT localhost:8080/api/account/change-password
+
+{
+    "old_password": "Coder2k123!",
+    "new_password": "Coder4k123!"
+}

--- a/requests/account/change_username.http
+++ b/requests/account/change_username.http
@@ -1,0 +1,15 @@
+POST http://localhost:8080/api/account/login
+
+{
+  "username_or_email": "coder2k",
+  "password": "Coder2k123!"
+}
+
+###
+
+PUT localhost:8080/api/account/change-username
+
+{
+    "username": "coder4k",
+    "password": "Coder2k123!"
+}

--- a/requests/account/new_account.http
+++ b/requests/account/new_account.http
@@ -1,9 +1,9 @@
 POST localhost:8080/api/account/register
 
 {
-  "username": "ClausKleber",
-  "email": "claus@kleber.de",
-  "password": "ClausKleber123!"
+  "username": "GundulaGause",
+  "email": "gundula@gause.de",
+  "password": "GundulaGause123!"
 }
 
 ###

--- a/requests/admin_dashboard/create_social_media_link_type.http
+++ b/requests/admin_dashboard/create_social_media_link_type.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/admin_dashboard/get_all_events.http
+++ b/requests/admin_dashboard/get_all_events.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/admin_dashboard/get_social_media_link_approvals.http
+++ b/requests/admin_dashboard/get_social_media_link_approvals.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/admin_dashboard/get_speaker_approvals.http
+++ b/requests/admin_dashboard/get_speaker_approvals.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/admin_dashboard/get_speakers_for_event.http
+++ b/requests/admin_dashboard/get_speakers_for_event.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/admin_dashboard/get_team_member_approvals.http
+++ b/requests/admin_dashboard/get_team_member_approvals.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/admin_dashboard/update_event.http
+++ b/requests/admin_dashboard/update_event.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/globals/put.http
+++ b/requests/globals/put.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/speaker_dashboard/get_all_events.http
+++ b/requests/speaker_dashboard/get_all_events.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/speaker_dashboard/get_speaker.http
+++ b/requests/speaker_dashboard/get_speaker.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/speaker_dashboard/new_speaker.http
+++ b/requests/speaker_dashboard/new_speaker.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/speaker_dashboard/update_speaker.http
+++ b/requests/speaker_dashboard/update_speaker.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/speaker_dashboard/update_speaker_photo.http
+++ b/requests/speaker_dashboard/update_speaker_photo.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/team_member_dashboard/get_all_events.http
+++ b/requests/team_member_dashboard/get_all_events.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/time_slots/create_or_replace_time_slots.http
+++ b/requests/time_slots/create_or_replace_time_slots.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/time_slots/get_time_slots.http
+++ b/requests/time_slots/get_time_slots.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/user_dashboard/delete_social_media_link.http
+++ b/requests/user_dashboard/delete_social_media_link.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/user_dashboard/get_social_media_links.http
+++ b/requests/user_dashboard/get_social_media_links.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/user_dashboard/new_social_media_link.http
+++ b/requests/user_dashboard/new_social_media_link.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ###

--- a/requests/user_dashboard/update_social_media_links.http
+++ b/requests/user_dashboard/update_social_media_links.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/api/account/login
 
 {
   "username_or_email": "coder2k",
-  "password": "password"
+  "password": "Coder2k123!"
 }
 
 ### Update two links, change second link from GitHub to GitLab

--- a/tests/App/Controllers/AccountTest.php
+++ b/tests/App/Controllers/AccountTest.php
@@ -470,7 +470,7 @@ class AccountTest extends CIUnitTestCase
     {
         $result = $this->withBodyFormat('json')->post('account/login', [
             'username_or_email' => 'coder2k',
-            'password' => 'password',
+            'password' => 'Coder2k123!',
         ]);
         $result->assertStatus(200);
         $result->assertSessionHas('user_id');

--- a/tests/App/Controllers/AccountTest.php
+++ b/tests/App/Controllers/AccountTest.php
@@ -480,7 +480,7 @@ class AccountTest extends CIUnitTestCase
     {
         $result = $this->withBodyFormat('json')->post('account/login', [
             'username_or_email' => 'unknown',
-            'password' => 'password',
+            'password' => 'Password123!',
         ]);
         $result->assertStatus(404);
         $result->assertSessionMissing('user_id');
@@ -490,7 +490,7 @@ class AccountTest extends CIUnitTestCase
     {
         $result = $this->withBodyFormat('json')->post('account/login', [
             'username_or_email' => 'coder2k',
-            'password' => 'wrongpassword',
+            'password' => 'WrongPassword123!',
         ]);
         $result->assertStatus(401);
         $result->assertSessionMissing('user_id');

--- a/tests/App/Models/AccountModelTest.php
+++ b/tests/App/Models/AccountModelTest.php
@@ -128,7 +128,7 @@ class AccountModelTest extends CIUnitTestCase
         $result = $model->getAccountByUsernameOrEmail('coder2k');
         $this->assertIsArray($result);
         $this->assertEquals('coder2k', $result['username']);
-        $this->assertTrue(password_verify('Coder2k123!', $result['password']));
+        $this->assertTrue($model->checkPassword($result['user_id'], 'Coder2k123!'));
         $this->assertEquals('coder2k@test-conf.de', $result['email']);
     }
 
@@ -138,7 +138,7 @@ class AccountModelTest extends CIUnitTestCase
         $result = $model->getAccountByUsernameOrEmail('CoDeR2k');
         $this->assertIsArray($result);
         $this->assertEquals('coder2k', $result['username']);
-        $this->assertTrue(password_verify('Coder2k123!', $result['password']));
+        $this->assertTrue($model->checkPassword($result['user_id'], 'Coder2k123!'));
         $this->assertEquals('coder2k@test-conf.de', $result['email']);
     }
 
@@ -148,7 +148,7 @@ class AccountModelTest extends CIUnitTestCase
         $result = $model->getAccountByUsernameOrEmail('coder2k@test-conf.de');
         $this->assertIsArray($result);
         $this->assertEquals('coder2k', $result['username']);
-        $this->assertTrue(password_verify('Coder2k123!', $result['password']));
+        $this->assertTrue($model->checkPassword($result['user_id'], 'Coder2k123!'));
         $this->assertEquals('coder2k@test-conf.de', $result['email']);
     }
 
@@ -158,7 +158,7 @@ class AccountModelTest extends CIUnitTestCase
         $result = $model->getAccountByUsernameOrEmail('CoDeR2k@TEST-conf.de');
         $this->assertIsArray($result);
         $this->assertEquals('coder2k', $result['username']);
-        $this->assertTrue(password_verify('Coder2k123!', $result['password']));
+        $this->assertTrue($model->checkPassword($result['user_id'], 'Coder2k123!'));
         $this->assertEquals('coder2k@test-conf.de', $result['email']);
     }
 

--- a/tests/App/Models/AccountModelTest.php
+++ b/tests/App/Models/AccountModelTest.php
@@ -128,7 +128,7 @@ class AccountModelTest extends CIUnitTestCase
         $result = $model->getAccountByUsernameOrEmail('coder2k');
         $this->assertIsArray($result);
         $this->assertEquals('coder2k', $result['username']);
-        $this->assertTrue(password_verify('password', $result['password']));
+        $this->assertTrue(password_verify('Coder2k123!', $result['password']));
         $this->assertEquals('coder2k@test-conf.de', $result['email']);
     }
 
@@ -138,7 +138,7 @@ class AccountModelTest extends CIUnitTestCase
         $result = $model->getAccountByUsernameOrEmail('CoDeR2k');
         $this->assertIsArray($result);
         $this->assertEquals('coder2k', $result['username']);
-        $this->assertTrue(password_verify('password', $result['password']));
+        $this->assertTrue(password_verify('Coder2k123!', $result['password']));
         $this->assertEquals('coder2k@test-conf.de', $result['email']);
     }
 
@@ -148,7 +148,7 @@ class AccountModelTest extends CIUnitTestCase
         $result = $model->getAccountByUsernameOrEmail('coder2k@test-conf.de');
         $this->assertIsArray($result);
         $this->assertEquals('coder2k', $result['username']);
-        $this->assertTrue(password_verify('password', $result['password']));
+        $this->assertTrue(password_verify('Coder2k123!', $result['password']));
         $this->assertEquals('coder2k@test-conf.de', $result['email']);
     }
 
@@ -158,7 +158,7 @@ class AccountModelTest extends CIUnitTestCase
         $result = $model->getAccountByUsernameOrEmail('CoDeR2k@TEST-conf.de');
         $this->assertIsArray($result);
         $this->assertEquals('coder2k', $result['username']);
-        $this->assertTrue(password_verify('password', $result['password']));
+        $this->assertTrue(password_verify('Coder2k123!', $result['password']));
         $this->assertEquals('coder2k@test-conf.de', $result['email']);
     }
 


### PR DESCRIPTION
This PR adds three new endpoints, for all of which the user has to be logged in (but no specific role is required):
- `PUT api/account/change-username`: Requires data of this structure:
  ```json5
  {
      "username": "coder4k",
      "password": "Coder2k123!"
  }
  ```
  Possible errors:
  - `WRONG_PASSWORD` (401)
  - `USERNAME_ALREADY_TAKEN` (400)

  Otherwise returns `{ "message": "USERNAME_CHANGED" }` on success.

- `PUT api/account/change-password`: Requires data of the following structure:
  ```json
  {
      "old_password": "Coder2k123!",
      "new_password": "Coder4k123!"
  }
  ```
  possible errors:
  - `PASSWORDS_EQUAL` (400) if the new password is the same as the old one
  - `WRONG_PASSWORD` (401)

  Otherwise returns `{ "message": "PASSWORD_CHANGED" }` on success.

- `PUT api/account/change-email`: Requires data of the following structure:
  ```json
  {
      "password": "Coder2k123!",
      "email": "coder@2k.com"
  }
  ```
  Possible errors:
  - `WRONG_PASSWORD` (401)
  - `EMAILS_EQUAL` (400)
  - `EMAIL_ALREADY_TAKEN` (400)

  Otherwise returns `{ "message": "VERIFICATION_TOKEN_SENT" }` on success.

Besides the mentioned errors, of course there are also the errors coming from CodeIgniter's validators (e.g. if the password doesn't match the password requirements, or if some fields are missing, etc.).

I also replaced the manuel validation in the `login()` function with CodeIgniter validators. This also means that I had to change the password in the seeders (I changed it from `password` to `Coder2k123!`), because the old password did not pass the validation rules. Together with this, I had to adapt the unit tests and the `.http` files (that's why there are so many changed files).