### PR TITLE
endpoints to fetch a list of all pending or tentative/accepted talks for the speaker

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -72,7 +72,7 @@ $routes->put('dashboard/speaker/talk/(:num)', [Talk::class, 'change'], ['filter'
 $routes->put('dashboard/speaker/talk/(:num)/accept-time-slot', [Talk::class, 'acceptTimeSlot'], ['filter' => SpeakerAuthFilter::class]);
 $routes->put('dashboard/speaker/talk/(:num)/reject-time-slot', [Talk::class, 'rejectTimeSlot'], ['filter' => SpeakerAuthFilter::class]);
 $routes->get('dashboard/admin/pending-talks', [Talk::class, 'getAllPendingTalks'], ['filter' => AdminAuthFilter::class]);
-$routes->get('dashboard/admin/tentative-talks', [Talk::class, 'getAllTentativeTalks'], ['filter' => AdminAuthFilter::class]);
+$routes->get('dashboard/admin/tentative-or-accepted-talks/(:num)', [Talk::class, 'getAllTentativeOrAcceptedTalks'], ['filter' => AdminAuthFilter::class]);
 $routes->post('dashboard/admin/talk/(:num)/request-changes', [Talk::class, 'requestChanges'], ['filter' => AdminAuthFilter::class]);
 $routes->put('dashboard/admin/talk/(:num)/approve', [Talk::class, 'approve'], ['filter' => AdminAuthFilter::class]);
 $routes->post('dashboard/admin/talk/(:num)/reject', [Talk::class, 'reject'], ['filter' => AdminAuthFilter::class]);

--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -71,6 +71,8 @@ $routes->post('dashboard/speaker/submit-talk', [Talk::class, 'submit'], ['filter
 $routes->put('dashboard/speaker/talk/(:num)', [Talk::class, 'change'], ['filter' => SpeakerAuthFilter::class]);
 $routes->put('dashboard/speaker/talk/(:num)/accept-time-slot', [Talk::class, 'acceptTimeSlot'], ['filter' => SpeakerAuthFilter::class]);
 $routes->put('dashboard/speaker/talk/(:num)/reject-time-slot', [Talk::class, 'rejectTimeSlot'], ['filter' => SpeakerAuthFilter::class]);
+$routes->get('dashboard/speaker/pending-talks', [Talk::class, 'getPendingTalksForSpeaker'], ['filter' => SpeakerAuthFilter::class]);
+$routes->get('dashboard/speaker/tentative-or-accepted-talks/(:num)', [Talk::class, 'getTentativeOrAcceptedTalksForSpeaker'], ['filter' => SpeakerAuthFilter::class]);
 $routes->get('dashboard/admin/pending-talks', [Talk::class, 'getAllPendingTalks'], ['filter' => AdminAuthFilter::class]);
 $routes->get('dashboard/admin/tentative-or-accepted-talks/(:num)', [Talk::class, 'getAllTentativeOrAcceptedTalks'], ['filter' => AdminAuthFilter::class]);
 $routes->post('dashboard/admin/talk/(:num)/request-changes', [Talk::class, 'requestChanges'], ['filter' => AdminAuthFilter::class]);

--- a/app/Controllers/Talk.php
+++ b/app/Controllers/Talk.php
@@ -167,13 +167,13 @@ class Talk extends BaseController
         return $this->response->setJSON(['pending_talks' => $pendingTalks])->setStatusCode(200);
     }
 
-    public function getAllTentativeTalks(): ResponseInterface
+    public function getAllTentativeOrAcceptedTalks(int $eventId): ResponseInterface
     {
         $talkModel = model(TalkModel::class);
-        $tentativeTalks = $talkModel->getAllTentative();
+        $tentativeTalks = $talkModel->getAllTentativeOrAccepted($eventId);
 
         $tentativeTalks = $this->addAdditionalDataToTalks($tentativeTalks);
-        return $this->response->setJSON(['tentative_talks' => $tentativeTalks])->setStatusCode(200);
+        return $this->response->setJSON(['tentative_or_accepted_talks' => $tentativeTalks])->setStatusCode(200);
     }
 
     public function requestChanges(int $talkId): ResponseInterface

--- a/app/Controllers/Talk.php
+++ b/app/Controllers/Talk.php
@@ -154,6 +154,24 @@ class Talk extends BaseController
         return $this->response->setJSON(['success' => 'TALK_SUBMITTED'])->setStatusCode(201);
     }
 
+    public function getPendingTalksForSpeaker(): ResponseInterface
+    {
+        $talkModel = model(TalkModel::class);
+        $pendingTalks = $talkModel->getPendingForSpeaker($this->getLoggedInUserId());
+
+        $pendingTalks = $this->addAdditionalDataToTalks($pendingTalks);
+        return $this->response->setJSON(['pending_talks' => $pendingTalks])->setStatusCode(200);
+    }
+
+    public function getTentativeOrAcceptedTalksForSpeaker(int $eventId): ResponseInterface
+    {
+        $talkModel = model(TalkModel::class);
+        $tentativeTalks = $talkModel->getTentativeOrAcceptedForSpeaker($this->getLoggedInUserId(), $eventId);
+
+        $tentativeTalks = $this->addAdditionalDataToTalks($tentativeTalks);
+        return $this->response->setJSON(['tentative_talks' => $tentativeTalks])->setStatusCode(200);
+    }
+
     /** Gets all pending talks of all users. A pending talk is a talk that has been submitted
      * but hasn't been approved yet. It may contain requested changes.
      * @return ResponseInterface The response to return to the client.

--- a/app/Controllers/Talk.php
+++ b/app/Controllers/Talk.php
@@ -165,6 +165,11 @@ class Talk extends BaseController
 
     public function getTentativeOrAcceptedTalksForSpeaker(int $eventId): ResponseInterface
     {
+        $eventModel = model(EventModel::class);
+        if ($eventModel->getPublished($eventId) === null) {
+            return $this->response->setJSON(['error' => 'EVENT_NOT_FOUND'])->setStatusCode(404);
+        }
+
         $talkModel = model(TalkModel::class);
         $tentativeTalks = $talkModel->getTentativeOrAcceptedForSpeaker($this->getLoggedInUserId(), $eventId);
 
@@ -187,6 +192,11 @@ class Talk extends BaseController
 
     public function getAllTentativeOrAcceptedTalks(int $eventId): ResponseInterface
     {
+        $eventModel = model(EventModel::class);
+        if ($eventModel->getPublished($eventId) === null) {
+            return $this->response->setJSON(['error' => 'EVENT_NOT_FOUND'])->setStatusCode(404);
+        }
+
         $talkModel = model(TalkModel::class);
         $tentativeTalks = $talkModel->getAllTentativeOrAccepted($eventId);
 

--- a/app/Controllers/Talk.php
+++ b/app/Controllers/Talk.php
@@ -847,7 +847,7 @@ class Talk extends BaseController
             );
             $talk['suggested_time_slot'] =
                 isset($talk['time_slot_id']) && $talk['time_slot_id'] != null
-                    ? $timeSlotModel->get($talk['time_slot_id'])
+                    ? $timeSlotModel->get($talk['time_slot_id'])->toArray()
                     : null;
             unset($talk['time_slot_id']);
         }

--- a/app/Controllers/Talk.php
+++ b/app/Controllers/Talk.php
@@ -160,7 +160,7 @@ class Talk extends BaseController
         $pendingTalks = $talkModel->getPendingForSpeaker($this->getLoggedInUserId());
 
         $pendingTalks = $this->addAdditionalDataToTalks($pendingTalks);
-        return $this->response->setJSON(['pending_talks' => $pendingTalks])->setStatusCode(200);
+        return $this->response->setJSON($pendingTalks)->setStatusCode(200);
     }
 
     public function getTentativeOrAcceptedTalksForSpeaker(int $eventId): ResponseInterface
@@ -174,7 +174,7 @@ class Talk extends BaseController
         $tentativeTalks = $talkModel->getTentativeOrAcceptedForSpeaker($this->getLoggedInUserId(), $eventId);
 
         $tentativeTalks = $this->addAdditionalDataToTalks($tentativeTalks);
-        return $this->response->setJSON(['tentative_talks' => $tentativeTalks])->setStatusCode(200);
+        return $this->response->setJSON($tentativeTalks)->setStatusCode(200);
     }
 
     /** Gets all pending talks of all users. A pending talk is a talk that has been submitted
@@ -187,7 +187,7 @@ class Talk extends BaseController
         $pendingTalks = $talkModel->getAllPending();
 
         $pendingTalks = $this->addAdditionalDataToTalks($pendingTalks);
-        return $this->response->setJSON(['pending_talks' => $pendingTalks])->setStatusCode(200);
+        return $this->response->setJSON($pendingTalks)->setStatusCode(200);
     }
 
     public function getAllTentativeOrAcceptedTalks(int $eventId): ResponseInterface
@@ -201,7 +201,7 @@ class Talk extends BaseController
         $tentativeTalks = $talkModel->getAllTentativeOrAccepted($eventId);
 
         $tentativeTalks = $this->addAdditionalDataToTalks($tentativeTalks);
-        return $this->response->setJSON(['tentative_or_accepted_talks' => $tentativeTalks])->setStatusCode(200);
+        return $this->response->setJSON($tentativeTalks)->setStatusCode(200);
     }
 
     public function requestChanges(int $talkId): ResponseInterface

--- a/app/Models/TalkModel.php
+++ b/app/Models/TalkModel.php
@@ -112,7 +112,27 @@ class TalkModel extends Model
             ->findAll();
     }
 
-    public function getAllTentative(): array
+    public function getPendingForSpeaker(int $userId): array
+    {
+        return $this
+            ->select('id, event_id, user_id, title, description, notes, requested_changes, created_at')
+            ->where('user_id', $userId)
+            ->where('is_approved', false)
+            ->orderBy('created_at')
+            ->findAll();
+    }
+
+    public function getTentativeOrAcceptedForSpeaker(int $userId, int $eventId): array
+    {
+        return $this
+            ->select('id, event_id, user_id, title, description, notes, requested_changes, time_slot_id, time_slot_accepted, created_at')
+            ->where('event_id', $eventId)
+            ->where('user_id', $userId)
+            ->where('is_approved', true)
+            ->orderBy('created_at')
+            ->findAll();
+    }
+
     public function getAllTentativeOrAccepted(int $eventId): array
     {
         return $this

--- a/app/Models/TalkModel.php
+++ b/app/Models/TalkModel.php
@@ -113,11 +113,12 @@ class TalkModel extends Model
     }
 
     public function getAllTentative(): array
+    public function getAllTentativeOrAccepted(int $eventId): array
     {
         return $this
-            ->select('id, event_id, user_id, title, description, notes, requested_changes, time_slot_id, created_at')
+            ->select('id, event_id, user_id, title, description, notes, requested_changes, time_slot_id, time_slot_accepted, created_at')
             ->where('is_approved', true)
-            ->where('time_slot_accepted', false)
+            ->where('event_id', $eventId)
             ->orderBy('created_at')
             ->findAll();
     }

--- a/requests/talk/get_all_tentative_or_accepted_talks.http
+++ b/requests/talk/get_all_tentative_or_accepted_talks.http
@@ -1,0 +1,10 @@
+POST http://localhost:8080/api/account/login
+
+{
+  "username_or_email": "coder2k",
+  "password": "password"
+}
+
+###
+
+GET localhost:8080/api/dashboard/admin/tentative-or-accepted-talks

--- a/requests/talk/get_all_tentative_or_accepted_talks.http
+++ b/requests/talk/get_all_tentative_or_accepted_talks.http
@@ -7,4 +7,4 @@ POST http://localhost:8080/api/account/login
 
 ###
 
-GET localhost:8080/api/dashboard/admin/tentative-or-accepted-talks
+GET localhost:8080/api/dashboard/admin/tentative-or-accepted-talks/1

--- a/requests/talk/get_pending_talks_for_speaker.http
+++ b/requests/talk/get_pending_talks_for_speaker.http
@@ -1,0 +1,10 @@
+POST http://localhost:8080/api/account/login
+
+{
+  "username_or_email": "coder2k",
+  "password": "password"
+}
+
+###
+
+GET localhost:8080/api/dashboard/speaker/pending-talks

--- a/requests/talk/get_tentative_or_accepted_talks_for_speaker.http
+++ b/requests/talk/get_tentative_or_accepted_talks_for_speaker.http
@@ -7,4 +7,4 @@ POST http://localhost:8080/api/account/login
 
 ###
 
-GET localhost:8080/api/dashboard/admin/tentative-talks
+GET localhost:8080/api/dashboard/speaker/tentative-or-accepted-talks/1


### PR DESCRIPTION
This PR adds two new endpoints:
- `GET api/dashboard/speaker/pending-talks`: Requires the speaker role, returns an array of all pending (i.e. non-approved) talks or the currently logged in speaker. The returned data has the following structure:
  ```json5
  {
    "pending_talks": [
      {
        "id": 10,
        "event_id": 1,
        "title": "Programmieren wie ein Profi",
        "description": "In diesem Vortrag lernst du, wie du professionell programmierst.",
        "notes": "Ich kann nur am zweiten Tag der Konferenz.",
        "requested_changes": null,
        "created_at": "2025-01-11 13:53:15",
        "speaker": {
          "id": 2,
          "user_id": 1,
          "name": "coder2k",
          "short_bio": "Test-Conf Host, Software-Entwickler, freier Dozent, Twitch-Partner",
          "bio": "Michael (coder2k) hat vor über 20 Jahren 'Turbo Pascal und Delphi für Kids' gelesen und sich seitdem mit dem Programmieren in verschiedenen Programmiersprachen beschäftigt. Er ist tätig als Software-Entwickler im Embedded-Umfeld und freier Dozent. Seit drei Jahren programmiert er auch auf Twitch und ist seit Anfang 2024 Twitch-Partner. Michael ist es wichtig, Wissen mit anderen auszutauschen und sich dadurch gemeinsam weiterzuentwickeln und neue Dinge zu lernen – und daraus ist auch die Idee zur Test-Conf entstanden.",
          "photo": "images/coder2k.jpg",
          "photo_mime_type": "image/jpeg",
          "is_approved": true,
          "visible_from": "2024-06-01 15:00:00",
          "requested_changes": null
        },
        "tags": [
          {
            "color_index": 4,
            "text": "Programmierung"
          },
          {
            "color_index": 1,
            "text": "Maker"
          },
          {
            "color_index": 2,
            "text": "Hacking"
          }
        ],
        "possible_durations": [
          30,
          45,
          60
        ],
        "suggested_time_slot": null
      }
      // more talks...
    ]
  }
  ```

- `GET api/dashboard/speaker/tentative-or-accepted-talks/(:num)`, where `:num` is an event id: Requires the speaker role, returns an array of all tentative (i.e. approved, but without an accepted time slot) and accepted (i.e. approved with accepted time slot) events for the specified event for the currently logged in user. The returned data has the same structure as above, but with the additional field `time_slot_accepted` of type `bool`.
  Possible errors:
  - `EVENT_NOT_FOUND` (404)

Additionally, the endpoint `GET api/dashboard/admin/tentative-talks` has been changed to `GET api/dashboard/admin/tentative-or-accepted-talks/(:num)`. It now requires passing an event ID and it returnes not only tentative, but also accepted talks. The structure of the data is the same as for `GET api/dashboard/speaker/tentative-or-accepted-talks/(:num)`.