### PR TITLE
adding talk duration choices

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -39,6 +39,7 @@ $routes->get('globals', [Globals::class, 'get']);
 $routes->get('social-media-link-types', [Globals::class, 'getSocialMediaLinkTypes']);
 $routes->get('tags', [Globals::class, 'getTags']);
 $routes->get('talk-duration-choices', [Globals::class, 'getTalkDurationChoices']);
+$routes->post('talk-duration-choices', [Globals::class, 'addTalkDurationChoices'], ['filter' => AdminAuthFilter::class]);
 
 $routes->put('dashboard/admin/globals', [AdminDashboard::class, 'setGlobals'], ['filter' => AdminAuthFilter::class]);
 $routes->post('dashboard/admin/social-media-link-type', [AdminDashboard::class, 'createSocialMediaType'], ['filter' => AdminAuthFilter::class]);

--- a/app/Controllers/Globals.php
+++ b/app/Controllers/Globals.php
@@ -44,7 +44,8 @@ class Globals extends BaseController
         return $this->response->setJSON($model->all());
     }
 
-    public function getTags(): ResponseInterface {
+    public function getTags(): ResponseInterface
+    {
         $model = model(TagModel::class);
         return $this->response->setJSON($model->getAll());
     }

--- a/app/Controllers/Globals.php
+++ b/app/Controllers/Globals.php
@@ -11,6 +11,10 @@ use CodeIgniter\HTTP\ResponseInterface;
 
 class Globals extends BaseController
 {
+    const TALK_DURATION_CHOICES_RULES = [
+        'choices.*' => 'required|is_natural_no_zero',
+    ];
+
     public function get(): ResponseInterface
     {
         // get global settings
@@ -49,5 +53,26 @@ class Globals extends BaseController
     {
         $model = model(TalkDurationChoiceModel::class);
         return $this->response->setJSON($model->getAll());
+    }
+
+    public function addTalkDurationChoices(): ResponseInterface
+    {
+        $data = $this->request->getJSON(assoc: true);
+        if (!$this->validateData($data ?? [], self::TALK_DURATION_CHOICES_RULES)) {
+            return $this->response->setJSON($this->validator->getErrors())->setStatusCode(400);
+        }
+        $validData = $this->validator->getValidated();
+
+        $model = model(TalkDurationChoiceModel::class);
+        $existingChoices = $model->getAll();
+        $numAdded = 0;
+        foreach ($validData['choices'] as $choice) {
+            if (!in_array($choice, $existingChoices)) {
+                $model->add($choice);
+                ++$numAdded;
+            }
+        }
+
+        return $this->response->setJSON(['message' => "ADDED_{$numAdded}_CHOICES"])->setStatusCode(201);
     }
 }

--- a/app/Models/TalkDurationChoiceModel.php
+++ b/app/Models/TalkDurationChoiceModel.php
@@ -22,4 +22,9 @@ class TalkDurationChoiceModel extends Model
     {
         return array_column($this->select('duration')->orderBy('duration')->findAll(), 'duration');
     }
+
+    public function add(int $duration): void
+    {
+        $this->insert(['duration' => $duration]);
+    }
 }

--- a/requests/globals/add_talk_duration_choices.http
+++ b/requests/globals/add_talk_duration_choices.http
@@ -1,0 +1,14 @@
+POST http://localhost:8080/api/account/login
+
+{
+  "username_or_email": "coder2k",
+  "password": "password"
+}
+
+###
+
+POST localhost:8080/api/talk-duration-choices
+
+{
+    "choices": [13, 42]
+}


### PR DESCRIPTION
New endpoint added:

`POST api/talk-duration-choices`: Requires the admin role, expects data of the following structure:
```json
{
  "choices": [15, 30, 60]
}
```
Adds all durations that don't already exist. Returns:
```json5
{ "message": "ADDED_42_CHOICES" } // replace 42 with the actual number of replaced entries
```