### PR TITLE
ability to update or create tags

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -41,6 +41,8 @@ $routes->get('health', [HealthCheck::class, 'check']);
 $routes->get('globals', [Globals::class, 'get']);
 $routes->get('social-media-link-types', [Globals::class, 'getSocialMediaLinkTypes']);
 $routes->get('tags', [Globals::class, 'getTags']);
+$routes->put('tags', [Globals::class, 'updateTags'], ['filter' => AdminAuthFilter::class]);
+$routes->post('tags', [Globals::class, 'createTags'], ['filter' => AdminAuthFilter::class]);
 $routes->get('talk-duration-choices', [Globals::class, 'getTalkDurationChoices']);
 $routes->post('talk-duration-choices', [Globals::class, 'addTalkDurationChoices'], ['filter' => AdminAuthFilter::class]);
 

--- a/app/Controllers/Globals.php
+++ b/app/Controllers/Globals.php
@@ -15,6 +15,17 @@ class Globals extends BaseController
         'choices.*' => 'required|is_natural_no_zero',
     ];
 
+    const UPDATE_TAGS_RULES = [
+        'tags.*.id' => 'required|is_natural_no_zero',
+        'tags.*.text' => 'required|string|max_length[255]',
+        'tags.*.color_index' => 'required|is_natural_no_zero',
+    ];
+
+    const CREATE_TAGS_RULES = [
+        'tags.*.text' => 'required|string|max_length[255]',
+        'tags.*.color_index' => 'required|is_natural_no_zero',
+    ];
+
     public function get(): ResponseInterface
     {
         // get global settings
@@ -48,6 +59,54 @@ class Globals extends BaseController
     {
         $model = model(TagModel::class);
         return $this->response->setJSON($model->getAll());
+    }
+
+    public function updateTags(): ResponseInterface
+    {
+        $data = $this->request->getJSON(assoc: true);
+        if (!$this->validateData($data ?? [], self::UPDATE_TAGS_RULES)) {
+            return $this->response->setJSON($this->validator->getErrors())->setStatusCode(400);
+        }
+        $validData = $this->validator->getValidated();
+
+        $model = model(TagModel::class);
+        $existingTags = $model->getAll();
+
+        foreach ($validData['tags'] as $tag) {
+            if (!in_array($tag['id'], array_column($existingTags, 'id'))) {
+                return $this->response->setJSON(['error' => 'TAG_DOES_NOT_EXIST'])->setStatusCode(400);
+            }
+        }
+
+        foreach ($validData['tags'] as $tag) {
+            $model->change(id: $tag['id'], text: $tag['text'], colorIndex: $tag['color_index']);
+        }
+
+        return $this->response->setJSON(['message' => 'TAGS_UPDATED']);
+    }
+
+    public function createTags(): ResponseInterface
+    {
+        $data = $this->request->getJSON(assoc: true);
+        if (!$this->validateData($data ?? [], self::CREATE_TAGS_RULES)) {
+            return $this->response->setJSON($this->validator->getErrors())->setStatusCode(400);
+        }
+        $validData = $this->validator->getValidated();
+
+        $model = model(TagModel::class);
+        $existingTags = $model->getAll();
+
+        foreach ($validData['tags'] as $tag) {
+            if (in_array($tag['text'], array_column($existingTags, 'text'))) {
+                return $this->response->setJSON(['error' => 'TAG_ALREADY_EXISTS'])->setStatusCode(400);
+            }
+        }
+
+        foreach ($validData['tags'] as $tag) {
+            $model->createTag(text: $tag['text'], colorIndex: $tag['color_index']);
+        }
+
+        return $this->response->setJSON(['message' => 'TAGS_CREATED'])->setStatusCode(201);
     }
 
     public function getTalkDurationChoices(): ResponseInterface

--- a/app/Models/TagModel.php
+++ b/app/Models/TagModel.php
@@ -25,6 +25,16 @@ class TagModel extends Model
         return $this->select('id, text, color_index')->orderBy('text')->findAll();
     }
 
+    public function createTag(string $text, int $colorIndex): int
+    {
+        return $this->insert(['text' => $text, 'color_index' => $colorIndex]);
+    }
+
+    public function change(int $id, string $text, int $colorIndex): void
+    {
+        $this->update($id, ['text' => $text, 'color_index' => $colorIndex]);
+    }
+
     /** Returns an associative array with the talk IDs as keys and the corresponding
      * tags (as an array) as values.
      * @param int[] $talkIds The IDs of the talks.

--- a/requests/globals/create_tags.http
+++ b/requests/globals/create_tags.http
@@ -1,0 +1,23 @@
+POST http://localhost:8080/api/account/login
+
+{
+  "username_or_email": "coder2k",
+  "password": "password"
+}
+
+###
+
+POST http://localhost:8080/api/tags
+
+{
+  "tags": [
+    {
+        "text": "Garbage Collection",
+        "color_index": 4
+    },
+    {
+        "text": "RAII",
+        "color_index": 2
+    }
+  ]
+}

--- a/requests/globals/update_tags.http
+++ b/requests/globals/update_tags.http
@@ -1,0 +1,25 @@
+POST http://localhost:8080/api/account/login
+
+{
+  "username_or_email": "coder2k",
+  "password": "password"
+}
+
+###
+
+PUT http://localhost:8080/api/tags
+
+{
+  "tags": [
+    {
+        "id": 1,
+        "text": "Bastelclub",
+        "color_index": 1
+    },
+    {
+        "id": 2,
+        "text": "Forward Engineering",
+        "color_index": 3
+    }
+  ]
+}


### PR DESCRIPTION
Two new endpoints:
- `PUT api/tags`: Requires the admin role, allows changing existing tags. Expects data of the following structure:
  ```json
  {
    "tags": [
      {
          "id": 1,
          "text": "Bastelclub",
          "color_index": 1
      },
      {
          "id": 2,
          "text": "Forward Engineering",
          "color_index": 3
      }
    ]
  }
  ```
  Possible errors:
  - `TAG_DOES_NOT_EXIST` (400) if there's at least one tag whose ID does not exist

  Otherwise, returns `{ "message": "TAGS_UPDATED" }` on success.

- `POST api/tags`: Requires the admin role, allows changing existing tags. Expects data of the following structure:
  ```json
  {
    "tags": [
      {
          "text": "Garbage Collection",
          "color_index": 4
      },
      {
          "text": "RAII",
          "color_index": 2
      }
    ]
  }
  ```
  Possible errors:
  - `TAG_ALREADY_EXISTS` (400) if there's at least one whose `text` value matches an existing tag

  Otherwise, returns `{ "message": "TAGS_CREATED" }` on success.
