### PR TITLE
fix: only allow suggestion time slots with suitable duration

### DIFF
--- a/app/Controllers/Talk.php
+++ b/app/Controllers/Talk.php
@@ -439,6 +439,11 @@ class Talk extends BaseController
             return $this->response->setJSON(['error' => 'TIME_SLOT_ALREADY_OCCUPIED'])->setStatusCode(400);
         }
 
+        $possibleDurations = array_column(model(PossibleTalkDurationModel::class)->get($talkId), 'duration');
+        if (!in_array($timeSlot->duration, $possibleDurations)) {
+            return $this->response->setJSON(['error' => 'TIME_SLOT_INVALID_DURATION'])->setStatusCode(400);
+        }
+
         $talkModel->setTimeSlot($talkId, $validData['time_slot_id']);
 
         $accountModel = model(AccountModel::class);


### PR DESCRIPTION
Previously, it was possible to suggest any (non occupied) time slot to a speaker, even if the possible talk durations contradicted the time slot. Now, this is checked and rejected upon mismatch.