### PR TITLE
fix: event data includes talks of speakers that are not yet visible

### DIFF
--- a/app/Controllers/Event.php
+++ b/app/Controllers/Event.php
@@ -47,7 +47,7 @@ class Event extends BaseController
         if ($scheduleVisibleFrom === null || $scheduleVisibleFrom > date('Y-m-d H:i:s')) {
             $talks = [];
         } else {
-            $talks = $this->getApprovedTalks($eventId, $speakers);
+            $talks = $this->getVisibleApprovedTalks($eventId, $speakers);
         }
 
         $event['year'] = $year;
@@ -75,7 +75,7 @@ class Event extends BaseController
             return $this->response->setStatusCode(404);
         }
 
-        $talks = $this->getApprovedTalks($event['id'], $this->getPublishedContributors($event['id'], Role::SPEAKER));
+        $talks = $this->getVisibleApprovedTalks($event['id'], $this->getPublishedContributors($event['id'], Role::SPEAKER));
 
         // Generate ICS file content
         $icsContent = "BEGIN:VCALENDAR\n";
@@ -103,7 +103,7 @@ class Event extends BaseController
             ->setBody($icsContent);
     }
 
-    private function getApprovedTalks(int $eventId, array $speakers): array
+    private function getVisibleApprovedTalks(int $eventId, array $speakers): array
     {
         $talkModel = model(TalkModel::class);
         $talks = $talkModel->getApprovedByEventId($eventId);

--- a/app/Controllers/Event.php
+++ b/app/Controllers/Event.php
@@ -111,6 +111,9 @@ class Event extends BaseController
 
         $timeSlotById = $this->getTimeSlotMapping(array_column($talks, 'time_slot_id'));
 
+        /* @var array<int, array> $speakerById */
+        $speakerById = [];
+
         foreach ($talks as &$talk) {
             // Find the speaker for this talk based on their user_id.
             $talk['speaker_id'] = null;
@@ -118,11 +121,17 @@ class Event extends BaseController
             foreach ($speakers as $speaker) {
                 if ($speaker['user_id'] === $talk['user_id']) {
                     $talk['speaker_id'] = $speaker['id'];
+                    $speakerById[$speaker['id']] = $speaker;
                     break;
                 }
             }
         }
         unset($talk);
+
+        $talks = array_filter(
+            $talks,
+            fn ($talk) => $talk['speaker_id'] !== null
+        );
 
         $tagModel = model(TagModel::class);
         $tagMapping = $tagModel->getTagMapping($talkIds);

--- a/app/Controllers/Event.php
+++ b/app/Controllers/Event.php
@@ -15,11 +15,12 @@ use App\Models\TagModel;
 use App\Models\TalkModel;
 use App\Models\TeamMemberModel;
 use App\Models\TimeSlotModel;
+use CodeIgniter\HTTP\ResponseInterface;
 use InvalidArgumentException;
 
 class Event extends BaseController
 {
-    public function get(int|null $year = null)
+    public function get(int|null $year = null): ResponseInterface
     {
         $eventModel = model(EventModel::class);
         if ($year === null) {


### PR DESCRIPTION
It was possible to break the frontend when a talk was ready to be shown on the frontpage, but the corresponding speaker was not published at that point. This PR fixes this by hiding the talks of non-published speakers.