### PR TITLE
feat: endpoint to fetch username and email address of current user

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -30,6 +30,7 @@ $routes->post('account/reset-password', [Account::class, 'resetPassword']);
 $routes->post('account/login', [Account::class, 'login']);
 $routes->post('account/logout', [Account::class, 'logout']);
 $routes->post('account/verify', [Account::class, 'verify']);
+$routes->get('account', [Account::class, 'get'], ['filter' => AuthFilter::class]);
 $routes->put('account/change-username', [Account::class, 'changeUsername'], ['filter' => AuthFilter::class]);
 $routes->put('account/change-password', [Account::class, 'changePassword'], ['filter' => AuthFilter::class]);
 $routes->put('account/change-email', [Account::class, 'changeEmail'], ['filter' => AuthFilter::class]);

--- a/app/Controllers/Account.php
+++ b/app/Controllers/Account.php
@@ -366,6 +366,17 @@ class Account extends BaseController
         return $this->response->setJSON(['logout' => 'success']);
     }
 
+    public function get(): ResponseInterface
+    {
+        $userId = $this->getLoggedInUserId();
+        $accountModel = model(AccountModel::class);
+        $account = $accountModel->get($userId);
+        if ($account === null) {
+            return $this->response->setStatusCode(500);
+        }
+        return $this->response->setJSON($account);
+    }
+
     public function changeUsername(): ResponseInterface
     {
         $data = $this->request->getJSON(assoc: true);

--- a/requests/account/get_account_data.http
+++ b/requests/account/get_account_data.http
@@ -1,0 +1,10 @@
+POST http://localhost:8080/api/account/login
+
+{
+  "username_or_email": "coder2k",
+  "password": "Coder2k123!"
+}
+
+###
+
+GET localhost:8080/api/account


### PR DESCRIPTION
This PR adds a new endpoint:
`GET /api/account`, requires the user to be logged in: Returns data of the following structure:
```json
{
  "username": "coder2k",
  "email": "coder2k@test-conf.de"
}
```
Possible errors: None (except for authorization)