### PR TITLE
Fixed MySQL compatibility

### DIFF
--- a/app/Database/Migrations/2024-10-07-172154_AddTeamMember.php
+++ b/app/Database/Migrations/2024-10-07-172154_AddTeamMember.php
@@ -6,7 +6,7 @@ use CodeIgniter\Database\Migration;
 
 class AddTeamMember extends Migration
 {
-    public function up()
+    public function up(): void
     {
         // The Speaker table and the TeamMember table are exactly identical, except
         // for their name. Therefore, we can reuse the Speaker table fields for the
@@ -19,18 +19,27 @@ class AddTeamMember extends Migration
                 'type' => $field->type,
                 'constraint' => $field->max_length ?? null,
                 'unsigned' => $field->unsigned ?? false,
-                'null' => $field->null ?? false,
+                'null' => $field->nullable ?? false,
                 'default' => $field->default ?? null,
                 'auto_increment' => $field->name === 'id',
             ];
         }
+
+        // fixed strange behavior of copying the id field
+        unset($fields['id']);
+
+        $fields['id'] = [
+            'type' => 'INT',
+            'unsigned' => true,
+            'auto_increment' => true,
+        ];
 
         $this->forge->addField($fields);
         $this->forge->addPrimaryKey('id');
         $this->forge->createTable('TeamMember');
     }
 
-    public function down()
+    public function down(): void
     {
         $this->forge->dropTable('TeamMember');
     }

--- a/app/Database/Migrations/2024-10-09-154806_AddMediaPartner.php
+++ b/app/Database/Migrations/2024-10-09-154806_AddMediaPartner.php
@@ -6,7 +6,7 @@ use CodeIgniter\Database\Migration;
 
 class AddMediaPartner extends Migration
 {
-    public function up()
+    public function up(): void
     {
         // The MediaPartner table and the Sponsor table are exactly identical, except
         // for their name. Therefore, we can reuse the Sponsor table fields for the
@@ -19,18 +19,27 @@ class AddMediaPartner extends Migration
                 'type' => $field->type,
                 'constraint' => $field->max_length ?? null,
                 'unsigned' => $field->unsigned ?? false,
-                'null' => $field->null ?? false,
+                'null' => $field->nullable ?? false,
                 'default' => $field->default ?? null,
                 'auto_increment' => $field->name === 'id',
             ];
         }
+
+        // fixed strange behavior of copying the id field
+        unset($fields['id']);
+
+        $fields['id'] = [
+            'type' => 'INT',
+            'unsigned' => true,
+            'auto_increment' => true,
+        ];
 
         $this->forge->addField($fields);
         $this->forge->addPrimaryKey('id');
         $this->forge->createTable('MediaPartner');
     }
 
-    public function down()
+    public function down(): void
     {
         $this->forge->dropTable('MediaPartner');
     }


### PR DESCRIPTION
The object returned from $this->db->getFieldData uses the attribute nullable and not null (like in the config)

The "id" column is not created with the original config because primary key fields are not allowed to be null and are not allowed to have a default value.

The old version created a SQL Statement like this:
`id` int NULL DEFAULT NULL AUTO_INCREMENT,

Not a pretty fix but it works.