### PR TITLE
fix: mysql error on standard settings

### DIFF
--- a/app/Database/Migrations/2025-01-01-134252_ChangeRolesView.php
+++ b/app/Database/Migrations/2025-01-01-134252_ChangeRolesView.php
@@ -24,7 +24,7 @@ class ChangeRolesView extends Migration
                 ) AS is_speaker,
                 EXISTS (
                     SELECT 1
-                    FROM TeamMember t
+                    FROM TeamMember
                     WHERE TeamMember.user_id = Account.user_id AND (
                         TeamMember.is_approved = TRUE
                         OR TeamMember.requested_changes IS NOT NULL


### PR DESCRIPTION
MySQL Standard mode includes `ONLY_FULL_GROUP_BY`. With this setting enabled, the roles view throws an error in tests. The removal of the alias "FROM TeamMember t" (which is not used) to "FROM TeamMember" solves the error.

Tests are passing after this change.