### PR TITLE
fix: catch exception when trying to delete time slots that have already been assigned

### DIFF
--- a/app/Controllers/TimeSlot.php
+++ b/app/Controllers/TimeSlot.php
@@ -58,7 +58,13 @@ class TimeSlot extends BaseController
             return $validationResult;
         }
 
-        $timeSlotModel->deleteAllOfEvent($eventId);
+        if (!$timeSlotModel->deleteAllOfEvent($eventId)) {
+            return $this
+                ->response
+                ->setJSON(['error' => 'CANNOT_DELETE_ASSIGNED_TIME_SLOTS'])
+                ->setStatusCode(ResponseInterface::HTTP_BAD_REQUEST);
+        }
+
         if (!$timeSlotModel->store($timeSlots)) {
             // This happens when trying to store new time slots, even though there already are talks
             // that have been assigned to time slots (violation of foreign key constraint).

--- a/app/Models/TimeSlotModel.php
+++ b/app/Models/TimeSlotModel.php
@@ -47,9 +47,14 @@ class TimeSlotModel extends Model
      * Deletes all time slots for an event (if any).
      * @param int $eventId
      */
-    public function deleteAllOfEvent(int $eventId): void
+    public function deleteAllOfEvent(int $eventId): bool
     {
-        $this->where('event_id', $eventId)->delete();
+        try {
+            $this->where('event_id', $eventId)->delete();
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
This fixes the error that you described in #157. Instead of an exception, you will now get an error response (`CANNOT_DELETE_ASSIGNED_TIME_SLOTS`, 400).

However, please note that you will still have to make changes to your payload. You can find the expected format in the [example request file](https://github.com/TechStreamConference/website-backend/blob/d167f0d6531a4d889c2f33af74a0369ea292b5f3/requests/time_slots/create_or_replace_time_slots.http#L12-L60).