### PR TITLE
feat: add endpoint to fetch list of possible hosts of a panel discussion

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -68,6 +68,7 @@ $routes->put('dashboard/admin/approval/social-media-link/(:num)', [Approval::cla
 $routes->put('dashboard/admin/approval/social-media-link/(:num)/request-changes', [Approval::class, 'requestChangesForSocialMediaLink'], ['filter' => AdminAuthFilter::class]);
 
 $routes->post('dashboard/admin/talk/create', [Talk::class, 'create'], ['filter' => AdminAuthFilter::class]);
+$routes->get('dashboard/admin/talk/possible-hosts/(:num)', [Talk::class, 'getPossibleHosts'], ['filter' => AdminAuthFilter::class]);
 $routes->get('dashboard/admin/talk/(:num)/possible-guests', [Talk::class, 'getPossibleGuests'], ['filter' => AdminAuthFilter::class]);
 $routes->put('dashboard/admin/talk/(:num)/set-guests', [Talk::class, 'setGuests'], ['filter' => AdminAuthFilter::class]);
 

--- a/app/Controllers/Talk.php
+++ b/app/Controllers/Talk.php
@@ -124,6 +124,24 @@ class Talk extends BaseController
             ->setStatusCode(ResponseInterface::HTTP_CREATED);
     }
 
+    /** Gets all speakers that are suitable as host for a new panel discussion to take place
+     *  at the specified event.
+     *  @param int $eventId The event ID.
+     *  @return ResponseInterface The response to return to the client.
+     */
+    public function getPossibleHosts(int $eventId): ResponseInterface
+    {
+        $speakerModel = model(SpeakerModel::class);
+        $possibleHosts = $speakerModel->getApproved($eventId);
+
+        usort($possibleHosts, fn($a, $b) => $a['name'] <=> $b['name']);
+
+        return $this
+            ->response
+            ->setJSON($possibleHosts)
+            ->setStatusCode(ResponseInterface::HTTP_OK);
+    }
+
     /** Gets all speakers that are suitable as guests for a panel discussion.
      * @param int $talkId The talk ID of the panel discussion.
      * @return ResponseInterface The response to return to the client.

--- a/app/Controllers/Talk.php
+++ b/app/Controllers/Talk.php
@@ -131,6 +131,15 @@ class Talk extends BaseController
      */
     public function getPossibleHosts(int $eventId): ResponseInterface
     {
+        $eventModel = model(EventModel::class);
+        $event = $eventModel->get($eventId);
+        if ($event === null) {
+            return $this
+                ->response
+                ->setJSON(['error' => 'EVENT_NOT_FOUND'])
+                ->setStatusCode(ResponseInterface::HTTP_NOT_FOUND);
+        }
+
         $speakerModel = model(SpeakerModel::class);
         $possibleHosts = $speakerModel->getApproved($eventId);
 

--- a/requests/admin_dashboard/get_possible_hosts.http
+++ b/requests/admin_dashboard/get_possible_hosts.http
@@ -1,0 +1,10 @@
+POST http://localhost:8080/api/account/login
+
+{
+  "username_or_email": "coder2k",
+  "password": "Coder2k123!"
+}
+
+###
+
+GET localhost:8080/api/dashboard/admin/talk/possible-hosts/1


### PR DESCRIPTION
This PR adds a new endpoint `GET api/dashboard/admin/talk/possible-hosts/(:num)` where `(:num)` is the ID of an event. It returns data of the following structure:
```json5
[
  {
    "id": 8,
    "user_id": 5,
    "name": "ClausKleber",
    "short_bio": "ClausKleber",
    "bio": "ClausKleber",
    "photo": "1739204704_3ffe80190a57b8987a06.jpg",
    "visible_from": "2024-06-01 12:00:00"
  },
  // possibly more speakers...
]
```
The speakers in the response are suitable as a host for a new panel discussion. That means, the returned IDs can be used in `POST api/dashboard/admin/talk/create`.

Possible errors:
* `EVENT_NOT_FOUND` (404)