### PR TITLE
feat: add endpoint to fetch all tentative or accepted talks of a given event

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -88,6 +88,7 @@ $routes->get('dashboard/speaker/pending-talks', [Talk::class, 'getPendingTalksFo
 $routes->get('dashboard/speaker/tentative-or-accepted-talks/(:num)', [Talk::class, 'getTentativeOrAcceptedTalksForSpeaker'], ['filter' => SpeakerAuthFilter::class]);
 $routes->get('dashboard/admin/pending-talks', [Talk::class, 'getAllPendingTalks'], ['filter' => AdminAuthFilter::class]);
 $routes->get('dashboard/admin/tentative-talks', [Talk::class, 'getAllTentativeTalks'], ['filter' => AdminAuthFilter::class]);
+$routes->get('dashboard/admin/tentative-or-accepted-talks/(:num)', [Talk::class, 'getTentativeOrAcceptedTalksForEvent'], ['filter' => AdminAuthFilter::class]);
 $routes->post('dashboard/admin/talk/(:num)/request-changes', [Talk::class, 'requestChanges'], ['filter' => AdminAuthFilter::class]);
 $routes->put('dashboard/admin/talk/(:num)/approve', [Talk::class, 'approve'], ['filter' => AdminAuthFilter::class]);
 $routes->post('dashboard/admin/talk/(:num)/reject', [Talk::class, 'reject'], ['filter' => AdminAuthFilter::class]);

--- a/app/Controllers/Talk.php
+++ b/app/Controllers/Talk.php
@@ -420,6 +420,31 @@ class Talk extends BaseController
             ->setStatusCode(ResponseInterface::HTTP_OK);
     }
 
+    /** Gets all tentative or accepted talk of the given event.
+     * @param int $eventId The ID of the event.
+     * @return ResponseInterface The response to return to the client.
+     */
+    public function getTentativeOrAcceptedTalksForEvent(int $eventId): ResponseInterface
+    {
+        $eventModel = model(EventModel::class);
+        $event = $eventModel->get($eventId);
+        if ($event === null) {
+            return $this
+                ->response
+                ->setJSON(['error' => 'EVENT_NOT_FOUND'])
+                ->setStatusCode(ResponseInterface::HTTP_NOT_FOUND);
+        }
+
+        $talkModel = model(TalkModel::class);
+        $talks = $talkModel->getAllTentativeOrAccepted($eventId);
+
+        $talks = $this->addAdditionalDataToTalks($talks);
+        return $this
+            ->response
+            ->setJSON($talks)
+            ->setStatusCode(ResponseInterface::HTTP_OK);
+    }
+
     public function requestChanges(int $talkId): ResponseInterface
     {
         $data = $this->request->getJSON(assoc: true);

--- a/app/Models/TalkModel.php
+++ b/app/Models/TalkModel.php
@@ -143,6 +143,16 @@ class TalkModel extends Model
             ->findAll();
     }
 
+    public function getAllTentativeOrAccepted(int $eventId): array
+    {
+        return $this
+            ->select('id, event_id, user_id, title, description, notes, requested_changes, time_slot_id, time_slot_accepted, created_at')
+            ->where('event_id', $eventId)
+            ->where('is_approved', true)
+            ->orderBy('created_at')
+            ->findAll();
+    }
+
     public function get(int $talkId): ?array
     {
         return $this

--- a/requests/talk/get_all_tentative_or_accepted_talks.http
+++ b/requests/talk/get_all_tentative_or_accepted_talks.http
@@ -1,0 +1,10 @@
+POST http://localhost:8080/api/account/login
+
+{
+  "username_or_email": "coder2k",
+  "password": "Coder2k123!"
+}
+
+###
+
+GET localhost:8080/api/dashboard/admin/tentative-or-accepted-talks/1


### PR DESCRIPTION
This PR adds a new endpoint `GET api/dashboard/admin/tentative-or-accepted-talks/(:num)` where `(:num)` is the ID of an event. The response has the same structure as `GET api/dashboard/admin/tentative-talks`, but it only contains events for the given event and the events have to be either tentative or accepted.
Possible errors:
* `EVENT_NOT_FOUND` (404)