### PR TITLE
feat: group tag colors by categories

### DIFF
--- a/app/Database/Seeds/TagSeeder2024.php
+++ b/app/Database/Seeds/TagSeeder2024.php
@@ -8,7 +8,7 @@ class TagSeeder2024 extends Seeder
 {
     public function run(): void
     {
-        
+
         $this->db->table('Tag')->insert([
             'id' => 87,
             'text' => 'Accessibility (A11y)',
@@ -16,7 +16,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 57,
             'text' => 'Agile Methoden',
@@ -24,7 +24,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 13,
             'text' => 'Augmented Reality',
@@ -32,7 +32,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 2,
             'text' => 'Ausbildung',
@@ -40,7 +40,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 22,
             'text' => 'Big Data',
@@ -48,7 +48,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 72,
             'text' => 'Blockchain',
@@ -56,7 +56,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 31,
             'text' => 'C',
@@ -64,7 +64,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 32,
             'text' => 'C++',
@@ -72,7 +72,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 44,
             'text' => 'Clean Code',
@@ -80,7 +80,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 50,
             'text' => 'Cloud',
@@ -88,7 +88,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 85,
             'text' => 'Cloud',
@@ -96,7 +96,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 18,
             'text' => 'Community-Management',
@@ -104,7 +104,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 30,
             'text' => 'Computergrafik',
@@ -112,7 +112,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 11,
             'text' => 'Construct 3',
@@ -120,7 +120,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 59,
             'text' => 'Continuous Delivery',
@@ -128,7 +128,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 58,
             'text' => 'Continuous Integration',
@@ -136,7 +136,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 23,
             'text' => 'Data Science',
@@ -144,7 +144,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 68,
             'text' => 'Datenschutz',
@@ -152,7 +152,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 21,
             'text' => 'Deep Learning',
@@ -160,7 +160,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 40,
             'text' => 'Design Patterns',
@@ -168,7 +168,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 64,
             'text' => 'DevOps',
@@ -176,7 +176,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 1,
             'text' => 'Didaktik',
@@ -184,7 +184,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 52,
             'text' => 'Docker',
@@ -192,7 +192,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 65,
             'text' => 'Docker',
@@ -200,7 +200,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 41,
             'text' => 'Domain-Driven Design',
@@ -208,7 +208,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 26,
             'text' => 'Edge Computing',
@@ -216,7 +216,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 63,
             'text' => 'Ethik in der IT',
@@ -224,7 +224,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 60,
             'text' => 'Fehlerkultur',
@@ -232,7 +232,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 6,
             'text' => 'Game Design',
@@ -240,7 +240,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 5,
             'text' => 'Games-Branche',
@@ -248,7 +248,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 36,
             'text' => 'Go',
@@ -256,7 +256,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 54,
             'text' => 'GraphQL',
@@ -264,7 +264,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 74,
             'text' => 'GraphQL',
@@ -272,7 +272,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 15,
             'text' => 'Hacking',
@@ -280,7 +280,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 25,
             'text' => 'Internet of Things',
@@ -288,7 +288,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 73,
             'text' => 'JSON',
@@ -296,7 +296,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 3,
             'text' => 'Kindersoftware',
@@ -304,7 +304,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 17,
             'text' => 'Kommunikation',
@@ -312,7 +312,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 33,
             'text' => 'Kotlin',
@@ -320,7 +320,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 51,
             'text' => 'Kubernetes',
@@ -328,7 +328,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 66,
             'text' => 'Kubernetes',
@@ -336,7 +336,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 19,
             'text' => 'Künstliche Intelligenz (KI)',
@@ -344,7 +344,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 20,
             'text' => 'Machine Learning',
@@ -352,7 +352,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 24,
             'text' => 'Maker',
@@ -360,7 +360,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 49,
             'text' => 'Microservices',
@@ -368,7 +368,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 12,
             'text' => 'Mixed Reality',
@@ -376,7 +376,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 10,
             'text' => 'Multiplayer',
@@ -384,7 +384,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 28,
             'text' => 'Musik',
@@ -392,7 +392,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 62,
             'text' => 'Nachhaltigkeit',
@@ -400,7 +400,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 86,
             'text' => 'Netzwerk',
@@ -408,7 +408,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 77,
             'text' => 'Next.js',
@@ -416,7 +416,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 75,
             'text' => 'Node.js',
@@ -424,7 +424,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 78,
             'text' => 'Nuxt',
@@ -432,7 +432,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 39,
             'text' => 'Objektorientierung',
@@ -440,7 +440,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 48,
             'text' => 'Open Source',
@@ -448,7 +448,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 37,
             'text' => 'PHP',
@@ -456,7 +456,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 38,
             'text' => 'Parser',
@@ -464,7 +464,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 27,
             'text' => 'Party',
@@ -472,7 +472,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 42,
             'text' => 'Performance-Optimierung',
@@ -480,7 +480,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 43,
             'text' => 'Profiling',
@@ -488,7 +488,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 29,
             'text' => 'Programmierung',
@@ -496,7 +496,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 56,
             'text' => 'Projektmanagement',
@@ -504,7 +504,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 61,
             'text' => 'Quality Assurance (QA)',
@@ -512,7 +512,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 80,
             'text' => 'Quasar',
@@ -520,7 +520,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 79,
             'text' => 'React',
@@ -528,7 +528,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 45,
             'text' => 'Refactoring',
@@ -536,7 +536,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 16,
             'text' => 'Reverse Engeneering',
@@ -544,7 +544,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 35,
             'text' => 'Rust',
@@ -552,7 +552,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 9,
             'text' => 'Scriptable Objects',
@@ -560,7 +560,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 67,
             'text' => 'Security',
@@ -568,7 +568,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 53,
             'text' => 'Serverless',
@@ -576,7 +576,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 83,
             'text' => 'Serverless',
@@ -584,7 +584,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 4,
             'text' => 'Spieleentwicklung',
@@ -592,7 +592,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 69,
             'text' => 'Streaming',
@@ -600,7 +600,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 76,
             'text' => 'Svelte',
@@ -608,7 +608,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 34,
             'text' => 'Swift',
@@ -616,7 +616,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 82,
             'text' => 'Symfony',
@@ -624,7 +624,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 46,
             'text' => 'Test-Driven Development',
@@ -632,7 +632,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 47,
             'text' => 'Testautomatisierung',
@@ -640,7 +640,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 88,
             'text' => 'UI',
@@ -648,7 +648,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 89,
             'text' => 'UX',
@@ -656,7 +656,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 7,
             'text' => 'Unity',
@@ -664,7 +664,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 8,
             'text' => 'Unreal',
@@ -672,7 +672,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 14,
             'text' => 'Virtual Reality',
@@ -680,7 +680,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 81,
             'text' => 'Vue.js',
@@ -688,7 +688,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 70,
             'text' => 'Web-Entwicklung',
@@ -696,7 +696,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 71,
             'text' => 'Web3',
@@ -704,7 +704,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 55,
             'text' => 'WebSockets',
@@ -712,7 +712,7 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
         $this->db->table('Tag')->insert([
             'id' => 84,
             'text' => 'WebSockets',
@@ -720,6 +720,6 @@ class TagSeeder2024 extends Seeder
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-        
+
     }
 }

--- a/app/Database/Seeds/TagSeeder2024.php
+++ b/app/Database/Seeds/TagSeeder2024.php
@@ -8,670 +8,718 @@ class TagSeeder2024 extends Seeder
 {
     public function run(): void
     {
-
+        
         $this->db->table('Tag')->insert([
-            'id' => 1,
+            'id' => 87,
             'text' => 'Accessibility (A11y)',
-            'color_index' => 1,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 2,
-            'text' => 'Agile Methoden',
-            'color_index' => 2,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 3,
-            'text' => 'Augmented Reality',
-            'color_index' => 3,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 4,
-            'text' => 'Ausbildung',
-            'color_index' => 4,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 5,
-            'text' => 'Big Data',
-            'color_index' => 5,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 6,
-            'text' => 'Blockchain',
-            'color_index' => 6,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 7,
-            'text' => 'C',
-            'color_index' => 7,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 8,
-            'text' => 'C++',
-            'color_index' => 8,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 9,
-            'text' => 'Clean Code',
-            'color_index' => 9,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 10,
-            'text' => 'Cloud',
-            'color_index' => 10,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 11,
-            'text' => 'Community-Management',
-            'color_index' => 11,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 12,
-            'text' => 'Computergrafik',
-            'color_index' => 12,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 13,
-            'text' => 'Construct 3',
-            'color_index' => 13,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 14,
-            'text' => 'Continuous Delivery',
-            'color_index' => 14,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 15,
-            'text' => 'Continuous Integration',
-            'color_index' => 15,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 16,
-            'text' => 'Data Science',
-            'color_index' => 16,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 17,
-            'text' => 'Datenschutz',
-            'color_index' => 17,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 18,
-            'text' => 'Deep Learning',
-            'color_index' => 18,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 19,
-            'text' => 'Design Patterns',
-            'color_index' => 19,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 20,
-            'text' => 'DevOps',
-            'color_index' => 20,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 21,
-            'text' => 'Didaktik',
-            'color_index' => 21,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 22,
-            'text' => 'Docker',
-            'color_index' => 22,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 23,
-            'text' => 'Domain-Driven Design',
-            'color_index' => 23,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 24,
-            'text' => 'Edge Computing',
             'color_index' => 24,
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 25,
-            'text' => 'Ethik in der IT',
-            'color_index' => 25,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 26,
-            'text' => 'Fehlerkultur',
-            'color_index' => 26,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 27,
-            'text' => 'Game Design',
-            'color_index' => 27,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 28,
-            'text' => 'Games-Branche',
-            'color_index' => 28,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 29,
-            'text' => 'Go',
-            'color_index' => 29,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 30,
-            'text' => 'GraphQL',
-            'color_index' => 30,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 31,
-            'text' => 'Hacking',
-            'color_index' => 31,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 32,
-            'text' => 'Internet of Things',
-            'color_index' => 32,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 33,
-            'text' => 'JSON',
-            'color_index' => 33,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 34,
-            'text' => 'Kindersoftware',
-            'color_index' => 34,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 35,
-            'text' => 'Kommunikation',
-            'color_index' => 35,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 36,
-            'text' => 'Kotlin',
-            'color_index' => 36,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 37,
-            'text' => 'Kubernetes',
-            'color_index' => 37,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 38,
-            'text' => 'Künstliche Intelligenz (KI)',
-            'color_index' => 38,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 39,
-            'text' => 'Machine Learning',
-            'color_index' => 39,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 40,
-            'text' => 'Maker',
-            'color_index' => 40,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 41,
-            'text' => 'Microservices',
-            'color_index' => 41,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 42,
-            'text' => 'Mixed Reality',
-            'color_index' => 42,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 43,
-            'text' => 'Multiplayer',
-            'color_index' => 43,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 44,
-            'text' => 'Musik',
-            'color_index' => 44,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 45,
-            'text' => 'Nachhaltigkeit',
-            'color_index' => 45,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 46,
-            'text' => 'Netzwerk',
-            'color_index' => 46,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 47,
-            'text' => 'Next.js',
-            'color_index' => 47,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 48,
-            'text' => 'Node.js',
-            'color_index' => 48,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 49,
-            'text' => 'Nuxt',
-            'color_index' => 49,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 50,
-            'text' => 'Objektorientierung',
-            'color_index' => 50,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 51,
-            'text' => 'Open Source',
-            'color_index' => 51,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 52,
-            'text' => 'PHP',
-            'color_index' => 52,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 53,
-            'text' => 'Parser',
-            'color_index' => 53,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 54,
-            'text' => 'Party',
-            'color_index' => 54,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 55,
-            'text' => 'Performance-Optimierung',
-            'color_index' => 55,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 56,
-            'text' => 'Profiling',
-            'color_index' => 56,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
+        
         $this->db->table('Tag')->insert([
             'id' => 57,
-            'text' => 'Programmierung',
-            'color_index' => 57,
+            'text' => 'Agile Methoden',
+            'color_index' => 18,
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-
+        
         $this->db->table('Tag')->insert([
-            'id' => 58,
-            'text' => 'Projektmanagement',
-            'color_index' => 58,
+            'id' => 13,
+            'text' => 'Augmented Reality',
+            'color_index' => 4,
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-
+        
+        $this->db->table('Tag')->insert([
+            'id' => 2,
+            'text' => 'Ausbildung',
+            'color_index' => 2,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 22,
+            'text' => 'Big Data',
+            'color_index' => 10,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 72,
+            'text' => 'Blockchain',
+            'color_index' => 24,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 31,
+            'text' => 'C',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 32,
+            'text' => 'C++',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 44,
+            'text' => 'Clean Code',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 50,
+            'text' => 'Cloud',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 85,
+            'text' => 'Cloud',
+            'color_index' => 24,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 18,
+            'text' => 'Community-Management',
+            'color_index' => 8,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 30,
+            'text' => 'Computergrafik',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 11,
+            'text' => 'Construct 3',
+            'color_index' => 4,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
         $this->db->table('Tag')->insert([
             'id' => 59,
-            'text' => 'Quality Assurance (QA)',
-            'color_index' => 59,
+            'text' => 'Continuous Delivery',
+            'color_index' => 18,
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-
+        
         $this->db->table('Tag')->insert([
-            'id' => 60,
-            'text' => 'Quasar',
-            'color_index' => 60,
+            'id' => 58,
+            'text' => 'Continuous Integration',
+            'color_index' => 18,
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-
+        
         $this->db->table('Tag')->insert([
-            'id' => 61,
-            'text' => 'React',
-            'color_index' => 61,
+            'id' => 23,
+            'text' => 'Data Science',
+            'color_index' => 10,
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 62,
-            'text' => 'Refactoring',
-            'color_index' => 62,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 63,
-            'text' => 'Reverse Engeneering',
-            'color_index' => 63,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 64,
-            'text' => 'Rust',
-            'color_index' => 64,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 65,
-            'text' => 'Scriptable Objects',
-            'color_index' => 65,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 66,
-            'text' => 'Security',
-            'color_index' => 66,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 67,
-            'text' => 'Serverless',
-            'color_index' => 67,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
+        
         $this->db->table('Tag')->insert([
             'id' => 68,
-            'text' => 'Spieleentwicklung',
-            'color_index' => 68,
+            'text' => 'Datenschutz',
+            'color_index' => 20,
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-
+        
+        $this->db->table('Tag')->insert([
+            'id' => 21,
+            'text' => 'Deep Learning',
+            'color_index' => 10,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 40,
+            'text' => 'Design Patterns',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 64,
+            'text' => 'DevOps',
+            'color_index' => 18,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 1,
+            'text' => 'Didaktik',
+            'color_index' => 1,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 52,
+            'text' => 'Docker',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 65,
+            'text' => 'Docker',
+            'color_index' => 18,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 41,
+            'text' => 'Domain-Driven Design',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 26,
+            'text' => 'Edge Computing',
+            'color_index' => 12,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 63,
+            'text' => 'Ethik in der IT',
+            'color_index' => 18,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 60,
+            'text' => 'Fehlerkultur',
+            'color_index' => 18,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 6,
+            'text' => 'Game Design',
+            'color_index' => 4,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 5,
+            'text' => 'Games-Branche',
+            'color_index' => 4,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 36,
+            'text' => 'Go',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 54,
+            'text' => 'GraphQL',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 74,
+            'text' => 'GraphQL',
+            'color_index' => 24,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 15,
+            'text' => 'Hacking',
+            'color_index' => 5,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 25,
+            'text' => 'Internet of Things',
+            'color_index' => 12,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 73,
+            'text' => 'JSON',
+            'color_index' => 24,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 3,
+            'text' => 'Kindersoftware',
+            'color_index' => 2,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 17,
+            'text' => 'Kommunikation',
+            'color_index' => 7,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 33,
+            'text' => 'Kotlin',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 51,
+            'text' => 'Kubernetes',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 66,
+            'text' => 'Kubernetes',
+            'color_index' => 18,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 19,
+            'text' => 'Künstliche Intelligenz (KI)',
+            'color_index' => 9,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 20,
+            'text' => 'Machine Learning',
+            'color_index' => 10,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 24,
+            'text' => 'Maker',
+            'color_index' => 11,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 49,
+            'text' => 'Microservices',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 12,
+            'text' => 'Mixed Reality',
+            'color_index' => 4,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 10,
+            'text' => 'Multiplayer',
+            'color_index' => 4,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 28,
+            'text' => 'Musik',
+            'color_index' => 13,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 62,
+            'text' => 'Nachhaltigkeit',
+            'color_index' => 18,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 86,
+            'text' => 'Netzwerk',
+            'color_index' => 24,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 77,
+            'text' => 'Next.js',
+            'color_index' => 24,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 75,
+            'text' => 'Node.js',
+            'color_index' => 24,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 78,
+            'text' => 'Nuxt',
+            'color_index' => 24,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 39,
+            'text' => 'Objektorientierung',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 48,
+            'text' => 'Open Source',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 37,
+            'text' => 'PHP',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 38,
+            'text' => 'Parser',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 27,
+            'text' => 'Party',
+            'color_index' => 13,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 42,
+            'text' => 'Performance-Optimierung',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 43,
+            'text' => 'Profiling',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 29,
+            'text' => 'Programmierung',
+            'color_index' => 15,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 56,
+            'text' => 'Projektmanagement',
+            'color_index' => 17,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 61,
+            'text' => 'Quality Assurance (QA)',
+            'color_index' => 18,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 80,
+            'text' => 'Quasar',
+            'color_index' => 24,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 79,
+            'text' => 'React',
+            'color_index' => 24,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 45,
+            'text' => 'Refactoring',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 16,
+            'text' => 'Reverse Engeneering',
+            'color_index' => 6,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 35,
+            'text' => 'Rust',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 9,
+            'text' => 'Scriptable Objects',
+            'color_index' => 4,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 67,
+            'text' => 'Security',
+            'color_index' => 19,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 53,
+            'text' => 'Serverless',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 83,
+            'text' => 'Serverless',
+            'color_index' => 24,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 4,
+            'text' => 'Spieleentwicklung',
+            'color_index' => 3,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
         $this->db->table('Tag')->insert([
             'id' => 69,
             'text' => 'Streaming',
-            'color_index' => 69,
+            'color_index' => 21,
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 70,
-            'text' => 'Svelte',
-            'color_index' => 70,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 71,
-            'text' => 'Swift',
-            'color_index' => 71,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 72,
-            'text' => 'Symfony',
-            'color_index' => 72,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 73,
-            'text' => 'Test-Driven Development',
-            'color_index' => 73,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 74,
-            'text' => 'Testautomatisierung',
-            'color_index' => 74,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 75,
-            'text' => 'UI',
-            'color_index' => 75,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
+        
         $this->db->table('Tag')->insert([
             'id' => 76,
-            'text' => 'UX',
-            'color_index' => 76,
+            'text' => 'Svelte',
+            'color_index' => 24,
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-
+        
         $this->db->table('Tag')->insert([
-            'id' => 77,
-            'text' => 'Unity',
-            'color_index' => 77,
+            'id' => 34,
+            'text' => 'Swift',
+            'color_index' => 16,
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 78,
-            'text' => 'Unreal',
-            'color_index' => 78,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 79,
-            'text' => 'Virtual Reality',
-            'color_index' => 79,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 80,
-            'text' => 'Vue.js',
-            'color_index' => 80,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
-        $this->db->table('Tag')->insert([
-            'id' => 81,
-            'text' => 'Web-Entwicklung',
-            'color_index' => 81,
-            'created_at' => '2024-01-01 00:00:00',
-            'updated_at' => '2024-01-01 00:00:00',
-        ]);
-
+        
         $this->db->table('Tag')->insert([
             'id' => 82,
-            'text' => 'Web3',
-            'color_index' => 82,
+            'text' => 'Symfony',
+            'color_index' => 24,
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-
+        
         $this->db->table('Tag')->insert([
-            'id' => 83,
-            'text' => 'WebSockets',
-            'color_index' => 83,
+            'id' => 46,
+            'text' => 'Test-Driven Development',
+            'color_index' => 16,
             'created_at' => '2024-01-01 00:00:00',
             'updated_at' => '2024-01-01 00:00:00',
         ]);
-
+        
+        $this->db->table('Tag')->insert([
+            'id' => 47,
+            'text' => 'Testautomatisierung',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 88,
+            'text' => 'UI',
+            'color_index' => 24,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 89,
+            'text' => 'UX',
+            'color_index' => 24,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 7,
+            'text' => 'Unity',
+            'color_index' => 4,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 8,
+            'text' => 'Unreal',
+            'color_index' => 4,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 14,
+            'text' => 'Virtual Reality',
+            'color_index' => 4,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 81,
+            'text' => 'Vue.js',
+            'color_index' => 24,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 70,
+            'text' => 'Web-Entwicklung',
+            'color_index' => 23,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 71,
+            'text' => 'Web3',
+            'color_index' => 24,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 55,
+            'text' => 'WebSockets',
+            'color_index' => 16,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
+        $this->db->table('Tag')->insert([
+            'id' => 84,
+            'text' => 'WebSockets',
+            'color_index' => 24,
+            'created_at' => '2024-01-01 00:00:00',
+            'updated_at' => '2024-01-01 00:00:00',
+        ]);
+        
     }
 }

--- a/app/Database/Seeds/TalkHasTagSeeder2024.php
+++ b/app/Database/Seeds/TalkHasTagSeeder2024.php
@@ -8,379 +8,379 @@ class TalkHasTagSeeder2024 extends Seeder
 {
     public function run(): void
     {
-
+        
         // Katzen würden VISCA senden
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 1,
-            'tag_id' => 40, // Maker
+            'tag_id' => 24, // Maker
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 1,
-            'tag_id' => 63, // Reverse Engeneering
+            'tag_id' => 16, // Reverse Engeneering
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 1,
-            'tag_id' => 31, // Hacking
+            'tag_id' => 15, // Hacking
         ]);
-
-
+        
+        
         // Journey eines Rollenspiels. Wie wir angefangen und was wir gelernt haben.
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 2,
-            'tag_id' => 68, // Spieleentwicklung
+            'tag_id' => 4, // Spieleentwicklung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 2,
-            'tag_id' => 58, // Projektmanagement
+            'tag_id' => 56, // Projektmanagement
         ]);
-
-
+        
+        
         // In Farbe und Bunt I - Wie werden Farben im Computer gemacht
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 3,
-            'tag_id' => 57, // Programmierung
+            'tag_id' => 29, // Programmierung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 3,
-            'tag_id' => 12, // Computergrafik
+            'tag_id' => 30, // Computergrafik
         ]);
-
-
+        
+        
         // In Farbe und Bunt II - Wie werden Farben nicht im Computer gemacht
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 4,
-            'tag_id' => 57, // Programmierung
+            'tag_id' => 29, // Programmierung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 4,
-            'tag_id' => 12, // Computergrafik
+            'tag_id' => 30, // Computergrafik
         ]);
-
-
+        
+        
         // Talk: Zwischen Code und Karriere: Soziale Dynamiken und der Übergang zum Beruf
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 5,
-            'tag_id' => 21, // Didaktik
+            'tag_id' => 1, // Didaktik
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 5,
-            'tag_id' => 4, // Ausbildung
+            'tag_id' => 2, // Ausbildung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 5,
-            'tag_id' => 35, // Kommunikation
+            'tag_id' => 17, // Kommunikation
         ]);
-
-
+        
+        
         // Der Mythos „Diamond Problem“
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 6,
-            'tag_id' => 57, // Programmierung
+            'tag_id' => 29, // Programmierung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 6,
-            'tag_id' => 8, // C++
+            'tag_id' => 32, // C++
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 6,
-            'tag_id' => 50, // Objektorientierung
+            'tag_id' => 39, // Objektorientierung
         ]);
-
-
+        
+        
         // Kinder sind keine kleinen Erwachsenen
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 7,
-            'tag_id' => 68, // Spieleentwicklung
+            'tag_id' => 4, // Spieleentwicklung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 7,
-            'tag_id' => 27, // Game Design
+            'tag_id' => 6, // Game Design
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 7,
-            'tag_id' => 34, // Kindersoftware
+            'tag_id' => 3, // Kindersoftware
         ]);
-
-
+        
+        
         // Hypewelle vs. loyaler Kern – Welche Community passt am besten zu dir?
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 8,
             'tag_id' => 69, // Streaming
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 8,
-            'tag_id' => 11, // Community-Management
+            'tag_id' => 18, // Community-Management
         ]);
-
-
+        
+        
         // WTF?! Wieso geht das nicht? Grrrrrrr
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 9,
-            'tag_id' => 57, // Programmierung
+            'tag_id' => 29, // Programmierung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 9,
-            'tag_id' => 26, // Fehlerkultur
+            'tag_id' => 60, // Fehlerkultur
         ]);
-
-
+        
+        
         // Aftershow-Party
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 10,
-            'tag_id' => 44, // Musik
+            'tag_id' => 28, // Musik
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 10,
-            'tag_id' => 54, // Party
+            'tag_id' => 27, // Party
         ]);
-
-
+        
+        
         // Sei nicht wie RockStar Games – lerne parsen in O(N)
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 11,
-            'tag_id' => 57, // Programmierung
+            'tag_id' => 29, // Programmierung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 11,
-            'tag_id' => 7, // C
+            'tag_id' => 31, // C
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 11,
-            'tag_id' => 8, // C++
+            'tag_id' => 32, // C++
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 11,
-            'tag_id' => 33, // JSON
+            'tag_id' => 73, // JSON
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 11,
-            'tag_id' => 53, // Parser
+            'tag_id' => 38, // Parser
         ]);
-
-
+        
+        
         // Webentwicklung mit Symfony und Vue.js
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 12,
-            'tag_id' => 81, // Web-Entwicklung
+            'tag_id' => 70, // Web-Entwicklung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 12,
-            'tag_id' => 52, // PHP
+            'tag_id' => 37, // PHP
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 12,
-            'tag_id' => 72, // Symfony
+            'tag_id' => 82, // Symfony
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 12,
-            'tag_id' => 80, // Vue.js
+            'tag_id' => 81, // Vue.js
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 12,
-            'tag_id' => 66, // Security
+            'tag_id' => 67, // Security
         ]);
-
-
+        
+        
         // Scriptable-Object-Listen in Unity
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 13,
-            'tag_id' => 68, // Spieleentwicklung
+            'tag_id' => 4, // Spieleentwicklung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 13,
-            'tag_id' => 65, // Scriptable Objects
+            'tag_id' => 9, // Scriptable Objects
         ]);
-
-
+        
+        
         // Heiße Spur: Wie du mit Heatmaps herausfindest, was deine Spieler treiben
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 14,
-            'tag_id' => 68, // Spieleentwicklung
+            'tag_id' => 4, // Spieleentwicklung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 14,
-            'tag_id' => 77, // Unity
+            'tag_id' => 7, // Unity
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 14,
-            'tag_id' => 27, // Game Design
+            'tag_id' => 6, // Game Design
         ]);
-
-
+        
+        
         // Talk: Von Code bis Community: Game Development, Softwareentwicklung und die Welt der Hackerspaces
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 15,
-            'tag_id' => 40, // Maker
+            'tag_id' => 24, // Maker
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 15,
-            'tag_id' => 68, // Spieleentwicklung
+            'tag_id' => 4, // Spieleentwicklung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 15,
-            'tag_id' => 57, // Programmierung
+            'tag_id' => 29, // Programmierung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 15,
-            'tag_id' => 31, // Hacking
+            'tag_id' => 15, // Hacking
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 15,
-            'tag_id' => 28, // Games-Branche
+            'tag_id' => 5, // Games-Branche
         ]);
-
-
+        
+        
         // Quasar und sonst nix
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 16,
-            'tag_id' => 81, // Web-Entwicklung
+            'tag_id' => 70, // Web-Entwicklung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 16,
-            'tag_id' => 60, // Quasar
+            'tag_id' => 80, // Quasar
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 16,
-            'tag_id' => 80, // Vue.js
+            'tag_id' => 81, // Vue.js
         ]);
-
-
+        
+        
         // Von Unity zu Unreal
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 17,
-            'tag_id' => 68, // Spieleentwicklung
+            'tag_id' => 4, // Spieleentwicklung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 17,
-            'tag_id' => 77, // Unity
+            'tag_id' => 7, // Unity
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 17,
-            'tag_id' => 78, // Unreal
+            'tag_id' => 8, // Unreal
         ]);
-
-
+        
+        
         // Vom Skeptiker zum Fan: Wie du selbst deine Schwiegereltern von deinem Webdesign begeisterst
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 18,
-            'tag_id' => 81, // Web-Entwicklung
+            'tag_id' => 70, // Web-Entwicklung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 18,
-            'tag_id' => 75, // UI
+            'tag_id' => 88, // UI
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 18,
-            'tag_id' => 76, // UX
+            'tag_id' => 89, // UX
         ]);
-
-
+        
+        
         // Autoritativer Multiplayer Game Server mit Node
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 19,
-            'tag_id' => 68, // Spieleentwicklung
+            'tag_id' => 4, // Spieleentwicklung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 19,
-            'tag_id' => 48, // Node.js
+            'tag_id' => 75, // Node.js
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 19,
-            'tag_id' => 43, // Multiplayer
+            'tag_id' => 10, // Multiplayer
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 19,
-            'tag_id' => 46, // Netzwerk
+            'tag_id' => 86, // Netzwerk
         ]);
-
-
-        // Spiele entwickeln war nie leichter...oder?
-
+        
+        
+        // Spiele entwickeln war nie leichter...oder? 
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 20,
-            'tag_id' => 68, // Spieleentwicklung
+            'tag_id' => 4, // Spieleentwicklung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 20,
-            'tag_id' => 13, // Construct 3
+            'tag_id' => 11, // Construct 3
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 20,
-            'tag_id' => 28, // Games-Branche
+            'tag_id' => 5, // Games-Branche
         ]);
-
-
+        
+        
         // Ressourcenverwaltung unter C++
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 21,
-            'tag_id' => 57, // Programmierung
+            'tag_id' => 29, // Programmierung
         ]);
-
+        
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 21,
-            'tag_id' => 8, // C++
+            'tag_id' => 32, // C++
         ]);
-
-
+        
+        
     }
 }

--- a/app/Database/Seeds/TalkHasTagSeeder2024.php
+++ b/app/Database/Seeds/TalkHasTagSeeder2024.php
@@ -8,379 +8,379 @@ class TalkHasTagSeeder2024 extends Seeder
 {
     public function run(): void
     {
-        
+
         // Katzen würden VISCA senden
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 1,
             'tag_id' => 24, // Maker
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 1,
             'tag_id' => 16, // Reverse Engeneering
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 1,
             'tag_id' => 15, // Hacking
         ]);
-        
-        
+
+
         // Journey eines Rollenspiels. Wie wir angefangen und was wir gelernt haben.
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 2,
             'tag_id' => 4, // Spieleentwicklung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 2,
             'tag_id' => 56, // Projektmanagement
         ]);
-        
-        
+
+
         // In Farbe und Bunt I - Wie werden Farben im Computer gemacht
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 3,
             'tag_id' => 29, // Programmierung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 3,
             'tag_id' => 30, // Computergrafik
         ]);
-        
-        
+
+
         // In Farbe und Bunt II - Wie werden Farben nicht im Computer gemacht
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 4,
             'tag_id' => 29, // Programmierung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 4,
             'tag_id' => 30, // Computergrafik
         ]);
-        
-        
+
+
         // Talk: Zwischen Code und Karriere: Soziale Dynamiken und der Übergang zum Beruf
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 5,
             'tag_id' => 1, // Didaktik
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 5,
             'tag_id' => 2, // Ausbildung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 5,
             'tag_id' => 17, // Kommunikation
         ]);
-        
-        
+
+
         // Der Mythos „Diamond Problem“
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 6,
             'tag_id' => 29, // Programmierung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 6,
             'tag_id' => 32, // C++
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 6,
             'tag_id' => 39, // Objektorientierung
         ]);
-        
-        
+
+
         // Kinder sind keine kleinen Erwachsenen
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 7,
             'tag_id' => 4, // Spieleentwicklung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 7,
             'tag_id' => 6, // Game Design
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 7,
             'tag_id' => 3, // Kindersoftware
         ]);
-        
-        
+
+
         // Hypewelle vs. loyaler Kern – Welche Community passt am besten zu dir?
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 8,
             'tag_id' => 69, // Streaming
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 8,
             'tag_id' => 18, // Community-Management
         ]);
-        
-        
+
+
         // WTF?! Wieso geht das nicht? Grrrrrrr
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 9,
             'tag_id' => 29, // Programmierung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 9,
             'tag_id' => 60, // Fehlerkultur
         ]);
-        
-        
+
+
         // Aftershow-Party
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 10,
             'tag_id' => 28, // Musik
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 10,
             'tag_id' => 27, // Party
         ]);
-        
-        
+
+
         // Sei nicht wie RockStar Games – lerne parsen in O(N)
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 11,
             'tag_id' => 29, // Programmierung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 11,
             'tag_id' => 31, // C
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 11,
             'tag_id' => 32, // C++
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 11,
             'tag_id' => 73, // JSON
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 11,
             'tag_id' => 38, // Parser
         ]);
-        
-        
+
+
         // Webentwicklung mit Symfony und Vue.js
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 12,
             'tag_id' => 70, // Web-Entwicklung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 12,
             'tag_id' => 37, // PHP
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 12,
             'tag_id' => 82, // Symfony
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 12,
             'tag_id' => 81, // Vue.js
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 12,
             'tag_id' => 67, // Security
         ]);
-        
-        
+
+
         // Scriptable-Object-Listen in Unity
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 13,
             'tag_id' => 4, // Spieleentwicklung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 13,
             'tag_id' => 9, // Scriptable Objects
         ]);
-        
-        
+
+
         // Heiße Spur: Wie du mit Heatmaps herausfindest, was deine Spieler treiben
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 14,
             'tag_id' => 4, // Spieleentwicklung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 14,
             'tag_id' => 7, // Unity
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 14,
             'tag_id' => 6, // Game Design
         ]);
-        
-        
+
+
         // Talk: Von Code bis Community: Game Development, Softwareentwicklung und die Welt der Hackerspaces
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 15,
             'tag_id' => 24, // Maker
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 15,
             'tag_id' => 4, // Spieleentwicklung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 15,
             'tag_id' => 29, // Programmierung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 15,
             'tag_id' => 15, // Hacking
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 15,
             'tag_id' => 5, // Games-Branche
         ]);
-        
-        
+
+
         // Quasar und sonst nix
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 16,
             'tag_id' => 70, // Web-Entwicklung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 16,
             'tag_id' => 80, // Quasar
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 16,
             'tag_id' => 81, // Vue.js
         ]);
-        
-        
+
+
         // Von Unity zu Unreal
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 17,
             'tag_id' => 4, // Spieleentwicklung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 17,
             'tag_id' => 7, // Unity
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 17,
             'tag_id' => 8, // Unreal
         ]);
-        
-        
+
+
         // Vom Skeptiker zum Fan: Wie du selbst deine Schwiegereltern von deinem Webdesign begeisterst
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 18,
             'tag_id' => 70, // Web-Entwicklung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 18,
             'tag_id' => 88, // UI
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 18,
             'tag_id' => 89, // UX
         ]);
-        
-        
+
+
         // Autoritativer Multiplayer Game Server mit Node
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 19,
             'tag_id' => 4, // Spieleentwicklung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 19,
             'tag_id' => 75, // Node.js
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 19,
             'tag_id' => 10, // Multiplayer
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 19,
             'tag_id' => 86, // Netzwerk
         ]);
-        
-        
-        // Spiele entwickeln war nie leichter...oder? 
-        
+
+
+        // Spiele entwickeln war nie leichter...oder?
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 20,
             'tag_id' => 4, // Spieleentwicklung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 20,
             'tag_id' => 11, // Construct 3
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 20,
             'tag_id' => 5, // Games-Branche
         ]);
-        
-        
+
+
         // Ressourcenverwaltung unter C++
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 21,
             'tag_id' => 29, // Programmierung
         ]);
-        
+
         $this->db->table('TalkHasTag')->insert([
             'talk_id' => 21,
             'tag_id' => 32, // C++
         ]);
-        
-        
+
+
     }
 }


### PR DESCRIPTION
This PR groups the color indices of tags by certain categories.
For example: The tag `Spieleentwicklung` has `color_index == 3`. The "sub-tags" `Unity`, `Unreal`, `Game Design`, etc. have `color_index == 4`. That means: Odd values are for the main categories, even values are for sub-categories.