### PR TITLE
fix: include label into

### DIFF
--- a/app/Helpers/VideoRoomHelper.php
+++ b/app/Helpers/VideoRoomHelper.php
@@ -15,9 +15,15 @@ class VideoRoomHelper
         VideoSourceType $sourceType,
     ): string
     {
+        $label = "{$sourceType->value}_$name";
         $data = [
-            'label' => "{$name}_{$sourceType->value}",
-            $linkType->value => VideoRoomHelper::createId($eventId, $userId, $sourceType->value),
+            'label' => $label,
+            $linkType->value => VideoRoomHelper::createId(
+                $eventId,
+                $userId,
+                $sourceType->value,
+                $label
+            ),
             'room' => $roomId,
             'password' => $password,
         ];
@@ -43,8 +49,8 @@ class VideoRoomHelper
         return $randomString;
     }
 
-    private static function createId(int $eventId, int $userId, string $type): string
+    private static function createId(int $eventId, int $userId, string $type, string $label): string
     {
-        return md5("{$eventId}-{$userId}-{$type}");
+        return md5("$eventId-$userId-$type-$label");
     }
 }


### PR DESCRIPTION
From VDO.ninja's perspective, each video source is uniquely identified by its ID (that's the `&view=...` part of the URL). The current implementation uses an MD5 hash of `$eventId-$userId-$type` to generate an ID (e.g., `2-18-cam`). However, the spare links all share the same user ID `0` (because `0` can never be a valid user ID of a real user). This lead to the problem that all spare links had the same viewer ID and the corresponding video sources could not be differentiated.  
The new implementation also includes the `label` into the MD5 calculation. This makes the IDs unique.

> [!WARNING]
> This PR changes all existing video room links! Thus, it's important that speakers use the "fresh" links on the day of the event—they should not use some old link they've saved several days before as those won't be valid anymore.