### PR TITLE
feat: add endpoint to copy latest approved speaker entry into latest published event

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -81,6 +81,7 @@ $routes->post('dashboard/admin/time-slots/(:num)', [TimeSlot::class, 'create_or_
 $routes->get('dashboard/speaker/all-events', [SpeakerDashboard::class, 'getAllPublished'], ['filter' => SpeakerAuthFilter::class]);
 $routes->get('dashboard/speaker/event/(:num)', [SpeakerDashboard::class, 'getIfPublished'], ['filter' => SpeakerAuthFilter::class]);
 $routes->post('dashboard/speaker/event/(:num)', [SpeakerDashboard::class, 'createOrUpdateIfPublished'], ['filter' => SpeakerAuthFilter::class]);
+$routes->post('dashboard/speaker/copy-latest-approved-speaker-entry', [SpeakerDashboard::class, 'copyLatestApprovedSpeakerEntry'], ['filter' => SpeakerAuthFilter::class]);
 
 // For better organization, the following routes are defined in the Talk controller.
 $routes->get('dashboard/speaker/can-submit-talk', [Talk::class, 'canSubmit'], ['filter' => SpeakerAuthFilter::class]);

--- a/requests/speaker_dashboard/copy_latest_approved_speaker_entry.http
+++ b/requests/speaker_dashboard/copy_latest_approved_speaker_entry.http
@@ -1,0 +1,10 @@
+POST http://localhost/api/account/login
+
+{
+  "username_or_email": "coder2k",
+  "password": "Coder2k123!"
+}
+
+###
+
+POST http://localhost/api/dashboard/speaker/copy-latest-approved-speaker-entry


### PR DESCRIPTION
This PR adds the new endpoint `api/dashboard/speaker/copy-latest-approved-speaker-entry` (only accessible for speakers). It does not take any parameters and should (hopefully) simply does what one would expect 🤷