### PR TITLE
fix: set `is_visible_on_frontpage` to `false` if `frontpage_date` is null

### DIFF
--- a/app/Controllers/Event.php
+++ b/app/Controllers/Event.php
@@ -166,7 +166,7 @@ class Event extends BaseController
     private function addFrontpageVisibilityInformation(array &$event): void
     {
         $now = date('Y-m-d H:i:s');
-        $event['is_visible_on_frontpage'] = $event['frontpage_date'] <= $now;
+        $event['is_visible_on_frontpage'] = ($event['frontpage_date'] !== null && $event['frontpage_date'] <= $now);
     }
 
     /**


### PR DESCRIPTION
I checked whether “Veröffentlichungsuhrzeit Ablaufplan” also effects the value of `is_visible_on_frontpage`, but it doesn’t. So this fix should be fine.