### PR TITLE
add: deafen to vdo links

### DIFF
--- a/app/Helpers/VideoRoomHelper.php
+++ b/app/Helpers/VideoRoomHelper.php
@@ -29,7 +29,7 @@ class VideoRoomHelper
         ];
         $queryString = http_build_query($data);
         if ($linkType == VideoLinkType::PUSH) {
-            $queryString .= '&maxframerate=30&g=0&ssid';
+            $queryString .= '&maxframerate=30&audiogain=0&ssid&deafen';
         } else if ($linkType == VideoLinkType::VIEW) {
             $queryString .= '&solo';
         }


### PR DESCRIPTION
Sources will now be deafend.
The speaker can not see that. So I will mention that within the explanation.

Note: Both links (screen and cam) are deafed be now. Is that okay or should I somehow add a if statement there to only deafen the screen link. When we notice, that the speaker wonder why they can not hear anything even tho they did not klick the speaker, We definitely should add an if here. I did not see any hint within the speakers view, that they are deafend. This is a different behavior as for `&autogain=0`.

Note: I also put the long version of 'audiogain' there for better readability. 
Note: I considered to use `&mute` here since that is mentioned as the newer version but that is a local setting. As far as I know the director can not unmute a speaker then. So still using `&autogain=0` here for the initial mute.