### PR TITLE
feat: use start date for application

### DIFF
--- a/app/Controllers/SpeakerDashboard.php
+++ b/app/Controllers/SpeakerDashboard.php
@@ -245,7 +245,7 @@ class SpeakerDashboard extends ContributorDashboard
         // - The user must not have a pending speaker application for that year (i.e. the user doesn't have a
         //   speaker entry for that year, that is not approved).
         $eventModel = model(EventModel::class);
-        $latestPublishedEvent = $eventModel->getNextByStartDate();
+        $latestPublishedEvent = $eventModel->getNextApplication();
         if ($latestPublishedEvent === null) {
             // No event to apply for.
             return $this
@@ -302,7 +302,7 @@ class SpeakerDashboard extends ContributorDashboard
 
         // Get the most recent published event.
         $eventModel = model(EventModel::class);
-        $latestPublishedEvent = $eventModel->getNextByStartDate();
+        $latestPublishedEvent = $eventModel->getNextApplication();
 
         if ($latestPublishedEvent === null) {
             return $this

--- a/app/Controllers/SpeakerDashboard.php
+++ b/app/Controllers/SpeakerDashboard.php
@@ -245,7 +245,7 @@ class SpeakerDashboard extends ContributorDashboard
         // - The user must not have a pending speaker application for that year (i.e. the user doesn't have a
         //   speaker entry for that year, that is not approved).
         $eventModel = model(EventModel::class);
-        $latestPublishedEvent = $eventModel->getLatestPublished();
+        $latestPublishedEvent = $eventModel->getNextByStartDate();
         if ($latestPublishedEvent === null) {
             // No event to apply for.
             return $this
@@ -302,7 +302,7 @@ class SpeakerDashboard extends ContributorDashboard
 
         // Get the most recent published event.
         $eventModel = model(EventModel::class);
-        $latestPublishedEvent = $eventModel->getLatestPublished();
+        $latestPublishedEvent = $eventModel->getNextByStartDate();
 
         if ($latestPublishedEvent === null) {
             return $this

--- a/app/Models/EventModel.php
+++ b/app/Models/EventModel.php
@@ -77,12 +77,14 @@ class EventModel extends Model
             ->first();
     }
 
-    public function getNextByStartDate(): array|null
+    public function getNextApplication(): array|null
     {
+        $now = date('Y-m-d H:i:s');
         return $this
             ->select('id, title, subtitle, start_date, end_date, discord_url, twitch_url, presskit_url, youtube_channel_url, trailer_url, trailer_poster_url, trailer_subtitles_url, description_headline, description, schedule_visible_from, publish_date, frontpage_date, call_for_papers_start, call_for_papers_end')
-            ->where('start_date >=', date('Y-m-d H:i:s'))
-            ->orderBy('start_date', 'ASC')
+            ->where('call_for_papers_start <=',$now)
+            ->where('call_for_papers_end >=',$now)
+            ->orderBy('call_for_papers_start', 'DESC')
             ->first();
     }
 

--- a/app/Models/EventModel.php
+++ b/app/Models/EventModel.php
@@ -77,6 +77,15 @@ class EventModel extends Model
             ->first();
     }
 
+    public function getNextByStartDate(): array|null
+    {
+        return $this
+            ->select('id, title, subtitle, start_date, end_date, discord_url, twitch_url, presskit_url, youtube_channel_url, trailer_url, trailer_poster_url, trailer_subtitles_url, description_headline, description, schedule_visible_from, publish_date, frontpage_date, call_for_papers_start, call_for_papers_end')
+            ->where('start_date >=', date('Y-m-d H:i:s'))
+            ->orderBy('start_date', 'ASC')
+            ->first();
+    }
+
     public function get(int $eventId): array|null
     {
         return $this


### PR DESCRIPTION
I was curries so I tries something.
It seams to be pretty easy to not use the publish date of an event to filter for application.
So that is my first approach.

I now use the start date to get the upcoming event.
So it becomes possible to apply for an event even when the event is not published.

I this that okay because the Date is public all along.
So there is no data to hide and one could already apply for an event the day after the event.

What do you think about that?
Im not quite sure if it is a good Idea to just use the `start_date` here or if you rather should use the `start_application_date` here. 
We can discuss that.

We can also discuss if we event want to have that option.
If we have that option, that would mean, that we have to be careful with the `start_date` and the `start_aplication_date` since they are no longer connected to the `publish_date`.