### PR TITLE
fix: add missing jsonEncodeDepth property to Config\Format

### DIFF
--- a/app/Config/Format.php
+++ b/app/Config/Format.php
@@ -64,6 +64,15 @@ class Format extends BaseConfig
     ];
 
     /**
+     * --------------------------------------------------------------------------
+     * JSON Encode Depth
+     * --------------------------------------------------------------------------
+     *
+     * The maximum depth of JSON encoding. Matches the default from json_encode().
+     */
+    public int $jsonEncodeDepth = 512;
+
+    /**
      * A Factory method to return the appropriate formatter for the given mime type.
      *
      * @param  string  $mime


### PR DESCRIPTION
CodeIgniter v4.6.3 introduced Config\Format::$jsonEncodeDepth to configure JSON encoding depth. Without it, JSONFormatter throws 'Undefined property' on every JSON response.